### PR TITLE
clarify how the script is ran

### DIFF
--- a/manipulation/transformations/python/index.md
+++ b/manipulation/transformations/python/index.md
@@ -26,7 +26,7 @@ Temporary files can be written to a `/tmp/` folder. Do not use the `/data/` fold
 
 ## Python Script Requirements
 Python is sensitive to indentation. Make sure not to mix tabs and spaces. All files are assumed to be in UTF;
-`# coding=utf-8` at the beginning of the script is not needed. A Python script to be run within our environment must meet the following requirements:
+`# coding=utf-8` at the beginning of the script is not needed. Do not wrap your main function within the `if __name__ == '__main__':` block as it will not be ran. Simply calling it from withing the script is enough. A Python script to be run within our environment must meet the following requirements:
 
 ### Packages
 You can list extra packages in the UI. These packages are installed using [pip](https://pypi.python.org/pypi/pip).


### PR DESCRIPTION
It is a common practice to make scripts like this:
```python
def main():
    print("Hello keboola!")

if __name__ == '__main__":
    main()
```

However this did not work for my Python transformation, so I had to do:
```python
def main():
    print("Hello keboola!")

main()
```

 I guess it is because 
a) the script `/data/script.py` is only imported (thus`__name__` is not `'__main__'`)
b) running `eval()` on the file contents of `script.py`
c) the mistake is on my side

If it's `a`, or `b` I suppose it is wort it to clarify this in the docs. If it is `c` I am sorry for confusion (and I would be curious what could be the issue!)