### PR TITLE
fix (google-analytics): new OAuth callback urls for custom authorization

### DIFF
--- a/extractors/marketing-sales/google-analytics/index.md
+++ b/extractors/marketing-sales/google-analytics/index.md
@@ -129,7 +129,7 @@ To avoid hitting quota limits, you can use your own OAuth Client ID and Secret:
     ![Screenshot - Google API Console - Create Credentials](/extractors/marketing-sales/google-analytics/google_console_credentials.png)
     
 5. Choose **Web Application**. Into **Authorized redirect URIs** insert 
- ```https://oauth.keboola.com/authorize/keboola.ex-google-analytics-v4/callback	```
+ ```https://oauth.keboola.com/authorize/keboola.ex-google-analytics-v4/callback```
     and ```https://oauth.eu-central-1.keboola.com/authorize/keboola.ex-google-analytics-v4/callback```. 
     The second one is needed for the EU region.
 

--- a/extractors/marketing-sales/google-analytics/index.md
+++ b/extractors/marketing-sales/google-analytics/index.md
@@ -129,8 +129,8 @@ To avoid hitting quota limits, you can use your own OAuth Client ID and Secret:
     ![Screenshot - Google API Console - Create Credentials](/extractors/marketing-sales/google-analytics/google_console_credentials.png)
     
 5. Choose **Web Application**. Into **Authorized redirect URIs** insert 
- ```https://syrup.keboola.com/oauth-v2/authorize/keboola.ex-google-analytics-v4/callback```
-    and ```https://syrup.eu-central-1.keboola.com/oauth-v2/authorize/keboola.ex-google-analytics-v4/callback```. 
+ ```https://oauth.keboola.com/authorize/keboola.ex-google-analytics-v4/callback	```
+    and ```https://oauth.eu-central-1.keboola.com/authorize/keboola.ex-google-analytics-v4/callback```. 
     The second one is needed for the EU region.
 
 6. Click **Create** and a popup window will display your new Client ID and Client Secret credentials.


### PR DESCRIPTION
Replaced old callback urls with new ones in
https://help.keboola.com/extractors/marketing-sales/google-analytics/#custom-oauth-credentials