### PR TITLE
Rename app store

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/keboola/connection-docs.svg?branch=master)](https://travis-ci.org/keboola/connection-docs)
 
-How to write documentation [https://sites.google.com/keboola.com/devel-internal/dokumentace](https://sites.google.com/keboola.com/devel-internal/dokumentace)
+How to write documentation [https://keboola.atlassian.net/wiki/spaces/KB/pages/82935879/Public+documentation](https://keboola.atlassian.net/wiki/spaces/KB/pages/82935879/Public+documentation)
 
 ## Documentation Development
 

--- a/components/applications/index.md
+++ b/components/applications/index.md
@@ -21,7 +21,7 @@ All applications are **implemented as [components](https://developers.keboola.co
 and as such can be completely created by 3rd party developers. 
 You can even create your own application. 
 Applications can be created either for a particular end-user, or they may be offered 
-to all Keboola Connection customers; in that case they have to be registered in Keboola Connection App Store.
+to all Keboola Connection customers; in that case they have to be registered in Keboola Connection [Developer Portal](https://components.keboola.com/).
 
 Applications may
 


### PR DESCRIPTION
Nic jako **Keboola Connection App Store** nemáme, viz slack https://keboola.slack.com/archives/C0A5ZK1LY/p1596127474000800