### PR TITLE
AWS - New outbound IPs for consolidated accounts

### DIFF
--- a/components/extractors/ip-addresses/kbc-public-ip.json
+++ b/components/extractors/ip-addresses/kbc-public-ip.json
@@ -36,13 +36,13 @@
             "ipPrefix": "52.7.83.136/32",
             "vendor": "aws",
             "region": "us-east-1",
-            "service": "job-queue"
+            "service": "queue"
         },
         {
             "ipPrefix": "52.20.72.254/32",
             "vendor": "aws",
             "region": "us-east-1",
-            "service": "job-queue"
+            "service": "queue"
         },
         {
             "ipPrefix": "35.157.170.229/32",
@@ -60,13 +60,13 @@
             "ipPrefix": "3.66.248.180/32",
             "vendor": "aws",
             "region": "eu-central-1",
-            "service": "job-queue"
+            "service": "queue"
         },
         {
             "ipPrefix": "3.64.150.30/32",
             "vendor": "aws",
             "region": "eu-central-1",
-            "service": "job-queue"
+            "service": "queue"
         },
         {
             "ipPrefix": "149.72.196.5/32",

--- a/components/extractors/ip-addresses/kbc-public-ip.json
+++ b/components/extractors/ip-addresses/kbc-public-ip.json
@@ -75,18 +75,6 @@
             "service": "syrup"
         },
         {
-            "ipPrefix": "13.236.254.70/32",
-            "vendor": "aws",
-            "region": "ap-southeast-2",
-            "service": "syrup"
-        },
-        {
-            "ipPrefix": "13.54.182.53/32",
-            "vendor": "aws",
-            "region": "ap-southeast-2",
-            "service": "syrup"
-        },
-        {
             "ipPrefix": "40.127.144.42/32",
             "vendor": "azure",
             "region": "north-europe",

--- a/components/extractors/ip-addresses/kbc-public-ip.json
+++ b/components/extractors/ip-addresses/kbc-public-ip.json
@@ -33,6 +33,18 @@
             "service": "syrup"
         },
         {
+            "ipPrefix": "52.7.83.136/32",
+            "vendor": "aws",
+            "region": "us-east-1",
+            "service": "job-queue"
+        },
+        {
+            "ipPrefix": "52.20.72.254/32",
+            "vendor": "aws",
+            "region": "us-east-1",
+            "service": "job-queue"
+        },
+        {
             "ipPrefix": "35.157.170.229/32",
             "vendor": "aws",
             "region": "eu-central-1",
@@ -43,6 +55,18 @@
             "vendor": "aws",
             "region": "eu-central-1",
             "service": "syrup"
+        },
+        {
+            "ipPrefix": "3.66.248.180/32",
+            "vendor": "aws",
+            "region": "eu-central-1",
+            "service": "job-queue"
+        },
+        {
+            "ipPrefix": "3.64.150.30/32",
+            "vendor": "aws",
+            "region": "eu-central-1",
+            "service": "job-queue"
         },
         {
             "ipPrefix": "149.72.196.5/32",

--- a/components/ip-addresses/index.md
+++ b/components/ip-addresses/index.md
@@ -31,6 +31,8 @@ ALERT: when changing those, change also /components/ip-addresses/kbc-public-ip.j
 - `52.206.109.126`
 - `34.203.87.137`
 - `149.72.196.5`
+- `52.7.83.136`
+- `52.20.72.254`
 
 ## connection.eu-central-1.keboola.com
 For projects in the AWS EU [region](/overview/#regions) (AWS region `eu-central-1`), 
@@ -42,6 +44,8 @@ ALERT: when changing those, change also /components/ip-addresses/kbc-public-ip.j
 - `35.157.170.229`
 - `35.157.93.175`
 - `149.72.196.5`
+- `3.66.248.180`
+- `3.64.150.30`
 
 ## connection.north-europe.azure.keboola.com
 For projects in the Azure EU [region](/overview/#regions) (Azure region `north-europe`), 

--- a/components/ip-addresses/kbc-public-ip.json
+++ b/components/ip-addresses/kbc-public-ip.json
@@ -36,13 +36,13 @@
             "ipPrefix": "52.7.83.136/32",
             "vendor": "aws",
             "region": "us-east-1",
-            "service": "job-queue"
+            "service": "queue"
         },
         {
             "ipPrefix": "52.20.72.254/32",
             "vendor": "aws",
             "region": "us-east-1",
-            "service": "job-queue"
+            "service": "queue"
         },
         {
             "ipPrefix": "35.157.170.229/32",
@@ -60,13 +60,13 @@
             "ipPrefix": "3.66.248.180/32",
             "vendor": "aws",
             "region": "eu-central-1",
-            "service": "job-queue"
+            "service": "queue"
         },
         {
             "ipPrefix": "3.64.150.30/32",
             "vendor": "aws",
             "region": "eu-central-1",
-            "service": "job-queue"
+            "service": "queue"
         },
         {
             "ipPrefix": "149.72.196.5/32",

--- a/components/ip-addresses/kbc-public-ip.json
+++ b/components/ip-addresses/kbc-public-ip.json
@@ -75,18 +75,6 @@
             "service": "syrup"
         },
         {
-            "ipPrefix": "13.236.254.70/32",
-            "vendor": "aws",
-            "region": "ap-southeast-2",
-            "service": "syrup"
-        },
-        {
-            "ipPrefix": "13.54.182.53/32",
-            "vendor": "aws",
-            "region": "ap-southeast-2",
-            "service": "syrup"
-        },
-        {
             "ipPrefix": "40.127.144.42/32",
             "vendor": "azure",
             "region": "north-europe",

--- a/components/ip-addresses/kbc-public-ip.json
+++ b/components/ip-addresses/kbc-public-ip.json
@@ -33,6 +33,18 @@
             "service": "syrup"
         },
         {
+            "ipPrefix": "52.7.83.136/32",
+            "vendor": "aws",
+            "region": "us-east-1",
+            "service": "job-queue"
+        },
+        {
+            "ipPrefix": "52.20.72.254/32",
+            "vendor": "aws",
+            "region": "us-east-1",
+            "service": "job-queue"
+        },
+        {
             "ipPrefix": "35.157.170.229/32",
             "vendor": "aws",
             "region": "eu-central-1",
@@ -43,6 +55,18 @@
             "vendor": "aws",
             "region": "eu-central-1",
             "service": "syrup"
+        },
+        {
+            "ipPrefix": "3.66.248.180/32",
+            "vendor": "aws",
+            "region": "eu-central-1",
+            "service": "job-queue"
+        },
+        {
+            "ipPrefix": "3.64.150.30/32",
+            "vendor": "aws",
+            "region": "eu-central-1",
+            "service": "job-queue"
         },
         {
             "ipPrefix": "149.72.196.5/32",


### PR DESCRIPTION
Part of https://keboola.atlassian.net/browse/SRE-2035

Přidání nových outbound IPs nové EKS infra. Z těchno IPs začnou komunikovat až joby nové queue. Updatujeme dopředu a hodíme i do changelogu.

A vyhodil jsem z těch jsonů `ap-southeast-2` který už je vypnutý. 
Diff vypadá srozumitelněji po commitech...