### PR TITLE
More outbound IPs for Azure NE

### DIFF
--- a/components/ip-addresses/index.md
+++ b/components/ip-addresses/index.md
@@ -55,7 +55,9 @@ the following IP addresses are currently used:
 ALERT: when changing those, change also /components/ip-addresses/kbc-public-ip.json and /components/extractors/ip-addresses/kbc-public-ip.json
 {% endcomment %}
 - `40.127.144.42`
-
+- `20.82.252.94`
+- `20.82.252.129`
+- `20.82.252.124`
 
 ## IP Address Ranges in JSON
 We are publishing our current IP addresses in JSON format. To view them,

--- a/components/ip-addresses/kbc-public-ip.json
+++ b/components/ip-addresses/kbc-public-ip.json
@@ -79,6 +79,24 @@
             "vendor": "azure",
             "region": "north-europe",
             "service": "syrup"
+        },
+        {
+            "ipPrefix": "20.82.252.94/32",
+            "vendor": "azure",
+            "region": "north-europe",
+            "service": "syrup"
+        },
+        {
+            "ipPrefix": "20.82.252.129/32",
+            "vendor": "azure",
+            "region": "north-europe",
+            "service": "syrup"
+        },
+        {
+            "ipPrefix": "20.82.252.124/32",
+            "vendor": "azure",
+            "region": "north-europe",
+            "service": "syrup"
         }
     ]
 }


### PR DESCRIPTION
Related to: https://keboola.atlassian.net/browse/SRE-2734

V rámci incidentu https://keboola.pagerduty.com/incidents/PQ9Z15O jsem narazili na to že máme vystřílené SNAT porty. Museli jsme tedy přidat další outbound IPs abysme problém vyřešili. Takhle by to mělo být stabilizované i s prostorem pro škálování.

Ovlivňuje to kteří mají nastavený whitelist, s jednou novou IP ot běží už od minulého týdne, další dvě se přidaly dnes.
Publikuju pak in do news feed a changelogu.


