### PR TITLE
Add single table output example for arrays

### DIFF
--- a/components/extractors/database/mongodb/mapping.md
+++ b/components/extractors/database/mongodb/mapping.md
@@ -220,7 +220,67 @@ As you can see, joining those two tables will be as easy as pie.
 </td>
 </tr>
 <tr>
-<td>Mapping (Single table)</td>
+    
+</table>
+
+
+## Storing Nested Documents to Parent Table
+
+<table class="table table-bordered">
+<tr>
+<td>Document</td>
+<td>
+{% highlight javascript %}
+{
+    "_id" : ObjectId("5716054bee6e764c94fa7ddd"),
+    "name" : "MongoDB extractor",
+    "revisions" : [
+        {
+            "id" : "1c6262e",
+            "desc" : "First version"
+        },
+        {
+            "id" : "68fc980",
+            "desc" : "Second version"
+        }
+    ],
+    "status" : {
+        "isActive" : 1,
+        "isDeleted" : 0
+    }
+}
+{% endhighlight %}
+</td>
+</tr>
+<tr>
+<td>Document in Strict Mode</td>
+<td>
+{% highlight json %}
+{
+    "_id": {
+        "$oid" : "5716054bee6e764c94fa7ddd"
+    },
+    "name": "MongoDB extractor",
+    "revisions": [
+        {
+            "id": "1c6262e",
+            "desc": "First version"
+        },
+        {
+            "id": "68fc980",
+            "desc": "Second version"
+        }
+    ],
+    "status": {
+        "isActive": 1,
+        "isDeleted": 0
+    }
+}
+{% endhighlight %}
+</td>
+</tr>
+<tr>
+<td>Mapping</td>
 <td>
 {% highlight json %}
 {
@@ -238,10 +298,12 @@ As you can see, joining those two tables will be as easy as pie.
     "revisions.1.desc": "revision1"
 }
 {% endhighlight %}
-</td>
+
+Numbers after "revision" array define position of the object in the array. 0 is the first position.
+</td>    
 </tr>
 <tr>
-<td>Output (Single table)</td>
+<td>Output</td>
 <td>
 
 extractors
@@ -249,6 +311,8 @@ extractors
 <tr><th>id (marked as PK)</th><th>name</th><th>isActive</th><th>isDeleted</th><th>revision0</th><th>revision1</th></tr>
 <tr><td>5716054bee6e764c94fa7ddd</td><td>MongoDB extractor</td><td>1</td><td>0</td><td>First version</td><td>Second version</td></tr>
 </table>
+
+As you can see, values from the "revisions" array are stored in the columns of the "extractors" table.
 
 </td>
 </tr>

--- a/components/extractors/database/mongodb/mapping.md
+++ b/components/extractors/database/mongodb/mapping.md
@@ -299,7 +299,7 @@ As you can see, joining those two tables will be as easy as pie.
 }
 {% endhighlight %}
 
-Numbers after "revision" array define position of the object in the array. 0 is the first position.
+The numbers after the "revision" array define the position of the object in the array. 0 is the first position.
 </td>    
 </tr>
 <tr>
@@ -312,7 +312,7 @@ extractors
 <tr><td>5716054bee6e764c94fa7ddd</td><td>MongoDB extractor</td><td>1</td><td>0</td><td>First version</td><td>Second version</td></tr>
 </table>
 
-As you can see, values from the "revisions" array are stored in the columns of the "extractors" table.
+As you can see, the values from the "revisions" array are stored in the columns of the "extractors" table.
 
 </td>
 </tr>
@@ -406,7 +406,7 @@ extractors-tags
 </table>
 
 
-## Boolean values
+## Boolean Values
 
 <table class="table table-bordered">
 <tr>

--- a/components/extractors/database/mongodb/mapping.md
+++ b/components/extractors/database/mongodb/mapping.md
@@ -219,6 +219,39 @@ As you can see, joining those two tables will be as easy as pie.
 
 </td>
 </tr>
+<tr>
+<td>Mapping (Single table)</td>
+<td>
+{% highlight json %}
+{
+    "_id.$oid": {
+        "type": "column",
+        "mapping": {
+            "destination": "id",
+            "primaryKey": true
+        }
+    },
+    "name": "name",
+    "status.isActive": "isActive",
+    "status.isDeleted": "isDeleted",
+    "revisions.0.desc": "revision0",
+    "revisions.1.desc": "revision1"
+}
+{% endhighlight %}
+</td>
+</tr>
+<tr>
+<td>Output (Single table)</td>
+<td>
+
+extractors
+<table>
+<tr><th>id (marked as PK)</th><th>name</th><th>isActive</th><th>isDeleted</th><th>revision0</th><th>revision1</th></tr>
+<tr><td>5716054bee6e764c94fa7ddd</td><td>MongoDB extractor</td><td>1</td><td>0</td><td>First version</td><td>Second version</td></tr>
+</table>
+
+</td>
+</tr>
 </table>
 
 


### PR DESCRIPTION
Based on this ticket: https://keboola.zendesk.com/agent/tickets/20880
I want to add example of mapping array with nester properties to a single output table. The same way it's possible in the generic ex.