### PR TITLE
New legacy storage worker ips

### DIFF
--- a/components/ip-addresses/index.md
+++ b/components/ip-addresses/index.md
@@ -34,6 +34,10 @@ ALERT: when changing those, change also /components/ip-addresses/kbc-public-ip.j
 - `52.7.83.136`
 - `52.20.72.254`
 
+Storage workers outbound IPs for Bring Your Own Database Backed (BYODB):
+- `3.222.3.15`
+- `34.206.78.206`
+
 ## connection.eu-central-1.keboola.com
 For projects in the AWS EU [region](/overview/#regions) (AWS region `eu-central-1`), 
 the following IP addresses are currently used:
@@ -46,6 +50,10 @@ ALERT: when changing those, change also /components/ip-addresses/kbc-public-ip.j
 - `149.72.196.5`
 - `3.66.248.180`
 - `3.64.150.30`
+
+Storage workers outbound IPs for Bring Your Own Database Backed (BYODB):
+- `35.157.62.225`
+- `3.71.156.204`
 
 ## connection.north-europe.azure.keboola.com
 For projects in the Azure EU [region](/overview/#regions) (Azure region `north-europe`), 

--- a/components/ip-addresses/kbc-public-ip.json
+++ b/components/ip-addresses/kbc-public-ip.json
@@ -45,6 +45,18 @@
             "service": "queue"
         },
         {
+            "ipPrefix": "3.222.3.15/32",
+            "vendor": "aws",
+            "region": "us-east-1",
+            "service": "storage"
+        },
+        {
+            "ipPrefix": "34.206.78.206/32",
+            "vendor": "aws",
+            "region": "us-east-1",
+            "service": "storage"
+        },
+        {
             "ipPrefix": "35.157.170.229/32",
             "vendor": "aws",
             "region": "eu-central-1",
@@ -73,6 +85,18 @@
             "vendor": "sendgrid",
             "region": "eu-central-1",
             "service": "syrup"
+        },
+        {
+            "ipPrefix": "35.157.62.225/32",
+            "vendor": "aws",
+            "region": "eu-central-1",
+            "service": "storage"
+        },
+        {
+            "ipPrefix": "3.71.156.204/32",
+            "vendor": "aws",
+            "region": "eu-central-1",
+            "service": "storage"
         },
         {
             "ipPrefix": "40.127.144.42/32",


### PR DESCRIPTION
Related to: https://keboola.atlassian.net/browse/SRE-3256

Fixní IPs pro legacy storage workery, původně jsem si říkal že nechám jen v internal docs ale nakonec abych to předal exasol mi to přijde lepší takhle. Jakmile zkonsolidujeme connection tak se tyhle IPs zas odmažou.

Funkční firewall:
<img width="1910" alt="image" src="https://user-images.githubusercontent.com/903531/156517840-289b0fe9-3a5e-4195-889f-958084f8cbd3.png">

https://connection.eu-central-1.keboola.com/admin/projects/3191/queue/389636917
<img width="1500" alt="image" src="https://user-images.githubusercontent.com/903531/156517869-bb56a70f-b47a-4282-a4b6-789ba2b13c85.png">


