### PR TITLE
Add ga to navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -371,6 +371,9 @@ items:
         
       - url: /templates/ecommerce/
         title: eCommerce
+      
+      - url: /templates/google-analytics/
+        title: Google Analytics
         
   - url: /catalog/
     title: Data Catalog

--- a/templates/datahub/datahub.md
+++ b/templates/datahub/datahub.md
@@ -17,13 +17,13 @@ Before you start, have a working instance of DataHub and get an API token.
 ### Deploy DataHub
 In order to get started, you must have a working (and secure!) instance of DataHub deployed somewhere. There are detailed deployment docs for the following platforms and technologies:
 
-[Deploying to AWS | DataHub](https://datahubproject.io/docs/deploy/aws)
+[Deploying to AWS - DataHub](https://datahubproject.io/docs/deploy/aws)
 
-[Deploying to GCP | DataHub](https://datahubproject.io/docs/deploy/gcp)
+[Deploying to GCP - DataHub](https://datahubproject.io/docs/deploy/gcp)
 
-[Deploying with Docker | DataHub](https://datahubproject.io/docs/docker)
+[Deploying with Docker - DataHub](https://datahubproject.io/docs/docker)
 
-[Deploying with Kubernetes | DataHub](https://datahubproject.io/docs/deploy/kubernetes)
+[Deploying with Kubernetes - DataHub](https://datahubproject.io/docs/deploy/kubernetes)
 
 ***Warning:** Please ensure that you/the client have either removed or changed the credentials for the DataHub root user (default is datahub/datahub). Otherwise, you will get emails from “ethical security researchers” :-).* 
 


### PR DESCRIPTION
- updating nav to add GA to Templates (to make it public - https://help.keboola.com/templates/google-analytics/)

- fixing links in Templates/DataHub