### PR TITLE
Fix content overflowing

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -141,11 +141,17 @@ table {
 }
 
 .root {
+  overflow: auto;
+
   .container {
     &.main {
       background-color: $keboola-gray;
     }
   }
+}
+
+img {
+  max-width: 100% !important;
 }
 
 .header {


### PR DESCRIPTION
Jira issue: [UT-332](https://keboola.atlassian.net/browse/UT-332)
Relates to: https://github.com/keboola/developers-docs/pull/234

Fix overflowing content on mobile;

- Allow automatic overflow on main wrapper
- Limit width of all images to width of its parents

[UT-332]: https://keboola.atlassian.net/browse/UT-332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ