### PR TITLE
Change extractors billing in pricing

### DIFF
--- a/management/project/limits/index.md
+++ b/management/project/limits/index.md
@@ -52,7 +52,7 @@ If you need more information, please contact your CSM.
 
 | Types of jobs in Keboola Connection   | Base job                | Time credits          |
 |---------------------------------------|-------------------------|-----------------------|
-| **Extractor job**                     | 1 GB in                 | **Per contract**      |
+| **Extractor job**                     | 1 hour                  | **2**                 |
 | **Writer job**                        | 1 GB out                | **0.2**               |  
 | **SQL job / Workspace**               |                         |                       |
 | Small                                 | 1 hour                  | **6**                 |


### PR DESCRIPTION
Based on request from Jakub Stracina, I'm changing docs about extractors billing. Our current default pricing is 2 PPU/h and leaving "Per contract" there would be confusing for new clients and it would also allow unnecessary discussions about final credits amount.