### PR TITLE
IPs update

### DIFF
--- a/components/extractors/ip-addresses/kbc-public-ip.json
+++ b/components/extractors/ip-addresses/kbc-public-ip.json
@@ -45,6 +45,12 @@
             "service": "queue"
         },
         {
+            "ipPrefix": "149.72.196.5/32",
+            "vendor": "sendgrid",
+            "region": "us-east-1",
+            "service": "queue"
+        },
+        {
             "ipPrefix": "35.157.170.229/32",
             "vendor": "aws",
             "region": "eu-central-1",
@@ -75,6 +81,12 @@
             "service": "syrup"
         },
         {
+            "ipPrefix": "149.72.196.5/32",
+            "vendor": "sendgrid",
+            "region": "eu-central-1",
+            "service": "queue"
+        },
+        {
             "ipPrefix": "40.127.144.42/32",
             "vendor": "azure",
             "region": "north-europe",
@@ -119,6 +131,12 @@
         {
             "ipPrefix": "20.82.252.124/32",
             "vendor": "azure",
+            "region": "north-europe",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "149.72.196.5/32",
+            "vendor": "sendgrid",
             "region": "north-europe",
             "service": "queue"
         }

--- a/components/extractors/ip-addresses/kbc-public-ip.json
+++ b/components/extractors/ip-addresses/kbc-public-ip.json
@@ -45,6 +45,54 @@
             "service": "queue"
         },
         {
+            "ipPrefix": "3.213.250.110/32",
+            "vendor": "aws",
+            "region": "us-east-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "107.22.113.103/32",
+            "vendor": "aws",
+            "region": "us-east-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "54.144.9.113/32",
+            "vendor": "aws",
+            "region": "us-east-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "54.204.61.145/32",
+            "vendor": "aws",
+            "region": "us-east-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "34.239.7.70/32",
+            "vendor": "aws",
+            "region": "us-east-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "3.217.232.144/32",
+            "vendor": "aws",
+            "region": "us-east-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "3.222.3.15/32",
+            "vendor": "aws",
+            "region": "us-east-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "34.206.78.206/32",
+            "vendor": "aws",
+            "region": "us-east-1",
+            "service": "queue"
+        },
+        {
             "ipPrefix": "35.157.170.229/32",
             "vendor": "aws",
             "region": "eu-central-1",
@@ -64,6 +112,54 @@
         },
         {
             "ipPrefix": "3.64.150.30/32",
+            "vendor": "aws",
+            "region": "eu-central-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "3.74.28.187/32",
+            "vendor": "aws",
+            "region": "eu-central-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "18.158.155.128/32",
+            "vendor": "aws",
+            "region": "eu-central-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "35.157.208.189/32",
+            "vendor": "aws",
+            "region": "eu-central-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "3.72.243.47/32",
+            "vendor": "aws",
+            "region": "eu-central-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "18.193.225.37/32",
+            "vendor": "aws",
+            "region": "eu-central-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "3.127.158.56/32",
+            "vendor": "aws",
+            "region": "eu-central-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "35.157.62.225/32",
+            "vendor": "aws",
+            "region": "eu-central-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "3.71.156.204/32",
             "vendor": "aws",
             "region": "eu-central-1",
             "service": "queue"

--- a/components/extractors/ip-addresses/kbc-public-ip.json
+++ b/components/extractors/ip-addresses/kbc-public-ip.json
@@ -79,6 +79,48 @@
             "vendor": "azure",
             "region": "north-europe",
             "service": "syrup"
+        },
+        {
+            "ipPrefix": "20.82.252.94/32",
+            "vendor": "azure",
+            "region": "north-europe",
+            "service": "syrup"
+        },
+        {
+            "ipPrefix": "20.82.252.129/32",
+            "vendor": "azure",
+            "region": "north-europe",
+            "service": "syrup"
+        },
+        {
+            "ipPrefix": "20.82.252.124/32",
+            "vendor": "azure",
+            "region": "north-europe",
+            "service": "syrup"
+        },
+        {
+            "ipPrefix": "40.127.144.42/32",
+            "vendor": "azure",
+            "region": "north-europe",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "20.82.252.94/32",
+            "vendor": "azure",
+            "region": "north-europe",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "20.82.252.129/32",
+            "vendor": "azure",
+            "region": "north-europe",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "20.82.252.124/32",
+            "vendor": "azure",
+            "region": "north-europe",
+            "service": "queue"
         }
     ]
 }

--- a/components/extractors/ip-addresses/kbc-public-ip.json
+++ b/components/extractors/ip-addresses/kbc-public-ip.json
@@ -1,6 +1,6 @@
 {
-    "syncToken": "1496657321",
-    "createDate": "2018-09-14-10-08-39",
+    "syncToken": "1675843081",
+    "createDate": "2023-02-08",
     "prefixes": [
         {
             "ipPrefix": "34.224.0.188/32",

--- a/components/extractors/ip-addresses/kbc-public-ip.json
+++ b/components/extractors/ip-addresses/kbc-public-ip.json
@@ -90,30 +90,6 @@
             "ipPrefix": "40.127.144.42/32",
             "vendor": "azure",
             "region": "north-europe",
-            "service": "syrup"
-        },
-        {
-            "ipPrefix": "20.82.252.94/32",
-            "vendor": "azure",
-            "region": "north-europe",
-            "service": "syrup"
-        },
-        {
-            "ipPrefix": "20.82.252.129/32",
-            "vendor": "azure",
-            "region": "north-europe",
-            "service": "syrup"
-        },
-        {
-            "ipPrefix": "20.82.252.124/32",
-            "vendor": "azure",
-            "region": "north-europe",
-            "service": "syrup"
-        },
-        {
-            "ipPrefix": "40.127.144.42/32",
-            "vendor": "azure",
-            "region": "north-europe",
             "service": "queue"
         },
         {

--- a/components/extractors/ip-addresses/kbc-public-ip.json
+++ b/components/extractors/ip-addresses/kbc-public-ip.json
@@ -22,9 +22,9 @@
         },
         {
             "ipPrefix": "149.72.196.5/32",
-            "vendor": "sendgrid",
+            "vendor": "aws",
             "region": "us-east-1",
-            "service": "syrup"
+            "service": "email-delivery"
         },
         {
             "ipPrefix": "34.203.87.137/32",
@@ -41,12 +41,6 @@
         {
             "ipPrefix": "52.20.72.254/32",
             "vendor": "aws",
-            "region": "us-east-1",
-            "service": "queue"
-        },
-        {
-            "ipPrefix": "149.72.196.5/32",
-            "vendor": "sendgrid",
             "region": "us-east-1",
             "service": "queue"
         },
@@ -76,15 +70,9 @@
         },
         {
             "ipPrefix": "149.72.196.5/32",
-            "vendor": "sendgrid",
+            "vendor": "aws",
             "region": "eu-central-1",
-            "service": "syrup"
-        },
-        {
-            "ipPrefix": "149.72.196.5/32",
-            "vendor": "sendgrid",
-            "region": "eu-central-1",
-            "service": "queue"
+            "service": "email-delivery"
         },
         {
             "ipPrefix": "40.127.144.42/32",
@@ -112,9 +100,9 @@
         },
         {
             "ipPrefix": "149.72.196.5/32",
-            "vendor": "sendgrid",
+            "vendor": "azure",
             "region": "north-europe",
-            "service": "queue"
+            "service": "email-delivery"
         }
     ]
 }

--- a/components/ip-addresses/index.md
+++ b/components/ip-addresses/index.md
@@ -29,6 +29,14 @@ ALERT: when changing those, change also /components/ip-addresses/kbc-public-ip.j
 
 - `52.7.83.136`
 - `52.20.72.254`
+- `3.213.250.110`
+- `107.22.113.103`
+- `54.144.9.113`
+- `54.204.61.145`
+- `34.239.7.70`
+- `3.217.232.144`
+- `3.222.3.15`
+- `34.206.78.206`
 - `149.72.196.5` - Used only for email delivery.
 
 For projects running on [legacy Queue V1](https://changelog.keboola.com/2021-11-10-what-is-new-queue/) the following IP Addresses are used:
@@ -48,6 +56,14 @@ ALERT: when changing those, change also /components/ip-addresses/kbc-public-ip.j
 {% endcomment %}
 - `3.66.248.180`
 - `3.64.150.30`
+- `3.74.28.187`
+- `18.158.155.128`
+- `35.157.208.189`
+- `3.72.243.47`
+- `18.193.225.37`
+- `3.127.158.56`
+- `35.157.62.225`
+- `3.71.156.204`
 - `149.72.196.5` - Used only for email delivery.
 
 For projects running on [legacy Queue V1](https://changelog.keboola.com/2021-11-10-what-is-new-queue/) the following IP Addresses are used:

--- a/components/ip-addresses/index.md
+++ b/components/ip-addresses/index.md
@@ -21,7 +21,7 @@ Below are listed the available [Keboola Connection Stack endpoints](https://deve
 
 ## connection.keboola.com
 For projects in the default AWS US [region](/overview/#regions) (AWS region `us-east-1`), 
-the following IP addresses are currently for all new projects used:
+the following IP addresses are currently used for all new projects:
 
 {% comment %}
 ALERT: when changing those, change also /components/ip-addresses/kbc-public-ip.json and /components/extractors/ip-addresses/kbc-public-ip.json
@@ -40,8 +40,8 @@ For projects running on [legacy Queue V1](https://changelog.keboola.com/2021-11-
 
 
 ## connection.eu-central-1.keboola.com
-For projects in the AWS EU [region](/overview/#regions) (AWS region `eu-central-1`), 
-the following IP addresses are currently used:
+For projects in the AWS EU [region](/overview/#regions) (AWS region `eu-central-1`),
+the following IP addresses are currently used for all new projects:
 
 {% comment %}
 ALERT: when changing those, change also /components/ip-addresses/kbc-public-ip.json and /components/extractors/ip-addresses/kbc-public-ip.json

--- a/components/ip-addresses/index.md
+++ b/components/ip-addresses/index.md
@@ -27,12 +27,12 @@ the following IP addresses are currently for all new projects used:
 ALERT: when changing those, change also /components/ip-addresses/kbc-public-ip.json and /components/extractors/ip-addresses/kbc-public-ip.json
 {% endcomment %}
 
-- `149.72.196.5`
+- `149.72.196.5` - Used only for email delivery.
 - `52.7.83.136`
 - `52.20.72.254`
 
 For projects running on [legacy Queue V1](https://changelog.keboola.com/2021-11-10-what-is-new-queue/) the following IP Addresses are used:
-- `149.72.196.5`
+- `149.72.196.5` - Used only for email delivery.
 - `34.224.0.188`
 - `34.200.169.177`
 - `52.206.109.126`
@@ -46,12 +46,12 @@ the following IP addresses are currently used:
 {% comment %}
 ALERT: when changing those, change also /components/ip-addresses/kbc-public-ip.json and /components/extractors/ip-addresses/kbc-public-ip.json
 {% endcomment %}
-- `149.72.196.5`
+- `149.72.196.5` - Used only for email delivery.
 - `3.66.248.180`
 - `3.64.150.30`
 
 For projects running on [legacy Queue V1](https://changelog.keboola.com/2021-11-10-what-is-new-queue/) the following IP Addresses are used:
-- `149.72.196.5`
+- `149.72.196.5` - Used only for email delivery.
 - `35.157.170.229`
 - `35.157.93.175`
 
@@ -63,6 +63,7 @@ the following IP addresses are currently used:
 {% comment %}
 ALERT: when changing those, change also /components/ip-addresses/kbc-public-ip.json and /components/extractors/ip-addresses/kbc-public-ip.json
 {% endcomment %}
+- `149.72.196.5` - Used only for email delivery.
 - `40.127.144.42`
 - `20.82.252.94`
 - `20.82.252.129`

--- a/components/ip-addresses/index.md
+++ b/components/ip-addresses/index.md
@@ -27,16 +27,16 @@ the following IP addresses are currently used for all new projects:
 ALERT: when changing those, change also /components/ip-addresses/kbc-public-ip.json and /components/extractors/ip-addresses/kbc-public-ip.json
 {% endcomment %}
 
-- `149.72.196.5` - Used only for email delivery.
 - `52.7.83.136`
 - `52.20.72.254`
+- `149.72.196.5` - Used only for email delivery.
 
 For projects running on [legacy Queue V1](https://changelog.keboola.com/2021-11-10-what-is-new-queue/) the following IP Addresses are used:
-- `149.72.196.5` - Used only for email delivery.
 - `34.224.0.188`
 - `34.200.169.177`
 - `52.206.109.126`
 - `34.203.87.137`
+- `149.72.196.5` - Used only for email delivery.
 
 
 ## connection.eu-central-1.keboola.com
@@ -46,14 +46,14 @@ the following IP addresses are currently used for all new projects:
 {% comment %}
 ALERT: when changing those, change also /components/ip-addresses/kbc-public-ip.json and /components/extractors/ip-addresses/kbc-public-ip.json
 {% endcomment %}
-- `149.72.196.5` - Used only for email delivery.
 - `3.66.248.180`
 - `3.64.150.30`
+- `149.72.196.5` - Used only for email delivery.
 
 For projects running on [legacy Queue V1](https://changelog.keboola.com/2021-11-10-what-is-new-queue/) the following IP Addresses are used:
-- `149.72.196.5` - Used only for email delivery.
 - `35.157.170.229`
 - `35.157.93.175`
+- `149.72.196.5` - Used only for email delivery.
 
 
 ## connection.north-europe.azure.keboola.com
@@ -63,11 +63,11 @@ the following IP addresses are currently used:
 {% comment %}
 ALERT: when changing those, change also /components/ip-addresses/kbc-public-ip.json and /components/extractors/ip-addresses/kbc-public-ip.json
 {% endcomment %}
-- `149.72.196.5` - Used only for email delivery.
 - `40.127.144.42`
 - `20.82.252.94`
 - `20.82.252.129`
 - `20.82.252.124`
+- `149.72.196.5` - Used only for email delivery.
 
 ## IP Address Ranges in JSON
 We are publishing our current IP addresses in JSON format. To view them,
@@ -81,7 +81,10 @@ The JSON file contains an array of ranges (attribute `prefixes`), each of which 
  - `ipPrefix` — subnet mask (CIDR)
  - `vendor` — cloud service provider
  - `region` — cloud service region
- - `service` — Keboola application service (`queue` for Keboola Connection components, `syrup` for Keboola Connection components using legacy Queue V1)
+ - `service` — Keboola application service
+   - `queue` - for Keboola Connection components
+   - `syrup` - for Keboola Connection components using legacy Queue V1
+   - `email-delivery` - for outbound emails
 
 ### Sample JSON
 

--- a/components/ip-addresses/index.md
+++ b/components/ip-addresses/index.md
@@ -21,18 +21,22 @@ Below are listed the available [Keboola Connection Stack endpoints](https://deve
 
 ## connection.keboola.com
 For projects in the default AWS US [region](/overview/#regions) (AWS region `us-east-1`), 
-the following IP addresses are currently used:
+the following IP addresses are currently for all new projects used:
 
 {% comment %}
 ALERT: when changing those, change also /components/ip-addresses/kbc-public-ip.json and /components/extractors/ip-addresses/kbc-public-ip.json
 {% endcomment %}
+
+- `149.72.196.5`
+- `52.7.83.136`
+- `52.20.72.254`
+
+For projects running on [legacy Queue V1](https://changelog.keboola.com/2021-11-10-what-is-new-queue/) the following IP Addresses are used:
+- `149.72.196.5`
 - `34.224.0.188`
 - `34.200.169.177`
 - `52.206.109.126`
 - `34.203.87.137`
-- `149.72.196.5`
-- `52.7.83.136`
-- `52.20.72.254`
 
 
 ## connection.eu-central-1.keboola.com
@@ -42,11 +46,14 @@ the following IP addresses are currently used:
 {% comment %}
 ALERT: when changing those, change also /components/ip-addresses/kbc-public-ip.json and /components/extractors/ip-addresses/kbc-public-ip.json
 {% endcomment %}
-- `35.157.170.229`
-- `35.157.93.175`
 - `149.72.196.5`
 - `3.66.248.180`
 - `3.64.150.30`
+
+For projects running on [legacy Queue V1](https://changelog.keboola.com/2021-11-10-what-is-new-queue/) the following IP Addresses are used:
+- `149.72.196.5`
+- `35.157.170.229`
+- `35.157.93.175`
 
 
 ## connection.north-europe.azure.keboola.com

--- a/components/ip-addresses/index.md
+++ b/components/ip-addresses/index.md
@@ -81,7 +81,7 @@ The JSON file contains an array of ranges (attribute `prefixes`), each of which 
  - `ipPrefix` — subnet mask (CIDR)
  - `vendor` — cloud service provider
  - `region` — cloud service region
- - `service` — Keboola application service (`syrup` for Keboola Connection components)
+ - `service` — Keboola application service (`queue` for Keboola Connection components, `syrup` for Keboola Connection components using legacy Queue V1)
 
 ### Sample JSON
 
@@ -94,13 +94,13 @@ The JSON file contains an array of ranges (attribute `prefixes`), each of which 
             "ipPrefix": "34.224.0.188/32",
             "vendor": "aws",
             "region": "us-east-1",
-            "service": "syrup"
+            "service": "queue"
         },
         {
             "ipPrefix": "34.200.169.177/32",
             "vendor": "aws",
             "region": "us-east-1",
-            "service": "syrup"
+            "service": "queue"
         },
         ...
     ]

--- a/components/ip-addresses/index.md
+++ b/components/ip-addresses/index.md
@@ -34,9 +34,6 @@ ALERT: when changing those, change also /components/ip-addresses/kbc-public-ip.j
 - `52.7.83.136`
 - `52.20.72.254`
 
-Following IP addresses are still owned by Keboola but not used by Keboola Connection anymore. You can safely remove them from your firewalls:
-- `3.222.3.15`
-- `34.206.78.206`
 
 ## connection.eu-central-1.keboola.com
 For projects in the AWS EU [region](/overview/#regions) (AWS region `eu-central-1`), 
@@ -51,9 +48,6 @@ ALERT: when changing those, change also /components/ip-addresses/kbc-public-ip.j
 - `3.66.248.180`
 - `3.64.150.30`
 
-Following IP addresses are still owned by Keboola but not used by Keboola Connection anymore. You can safely remove them from your firewalls:
-- `35.157.62.225`
-- `3.71.156.204`
 
 ## connection.north-europe.azure.keboola.com
 For projects in the Azure EU [region](/overview/#regions) (Azure region `north-europe`), 

--- a/components/ip-addresses/kbc-public-ip.json
+++ b/components/ip-addresses/kbc-public-ip.json
@@ -45,6 +45,12 @@
             "service": "queue"
         },
         {
+            "ipPrefix": "149.72.196.5/32",
+            "vendor": "sendgrid",
+            "region": "us-east-1",
+            "service": "queue"
+        },
+        {
             "ipPrefix": "35.157.170.229/32",
             "vendor": "aws",
             "region": "eu-central-1",
@@ -75,6 +81,12 @@
             "service": "syrup"
         },
         {
+            "ipPrefix": "149.72.196.5/32",
+            "vendor": "sendgrid",
+            "region": "eu-central-1",
+            "service": "queue"
+        },
+        {
             "ipPrefix": "40.127.144.42/32",
             "vendor": "azure",
             "region": "north-europe",
@@ -119,6 +131,12 @@
         {
             "ipPrefix": "20.82.252.124/32",
             "vendor": "azure",
+            "region": "north-europe",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "149.72.196.5/32",
+            "vendor": "sendgrid",
             "region": "north-europe",
             "service": "queue"
         }

--- a/components/ip-addresses/kbc-public-ip.json
+++ b/components/ip-addresses/kbc-public-ip.json
@@ -45,6 +45,54 @@
             "service": "queue"
         },
         {
+            "ipPrefix": "3.213.250.110/32",
+            "vendor": "aws",
+            "region": "us-east-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "107.22.113.103/32",
+            "vendor": "aws",
+            "region": "us-east-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "54.144.9.113/32",
+            "vendor": "aws",
+            "region": "us-east-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "54.204.61.145/32",
+            "vendor": "aws",
+            "region": "us-east-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "34.239.7.70/32",
+            "vendor": "aws",
+            "region": "us-east-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "3.217.232.144/32",
+            "vendor": "aws",
+            "region": "us-east-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "3.222.3.15/32",
+            "vendor": "aws",
+            "region": "us-east-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "34.206.78.206/32",
+            "vendor": "aws",
+            "region": "us-east-1",
+            "service": "queue"
+        },
+        {
             "ipPrefix": "35.157.170.229/32",
             "vendor": "aws",
             "region": "eu-central-1",
@@ -64,6 +112,54 @@
         },
         {
             "ipPrefix": "3.64.150.30/32",
+            "vendor": "aws",
+            "region": "eu-central-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "3.74.28.187/32",
+            "vendor": "aws",
+            "region": "eu-central-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "18.158.155.128/32",
+            "vendor": "aws",
+            "region": "eu-central-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "35.157.208.189/32",
+            "vendor": "aws",
+            "region": "eu-central-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "3.72.243.47/32",
+            "vendor": "aws",
+            "region": "eu-central-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "18.193.225.37/32",
+            "vendor": "aws",
+            "region": "eu-central-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "3.127.158.56/32",
+            "vendor": "aws",
+            "region": "eu-central-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "35.157.62.225/32",
+            "vendor": "aws",
+            "region": "eu-central-1",
+            "service": "queue"
+        },
+        {
+            "ipPrefix": "3.71.156.204/32",
             "vendor": "aws",
             "region": "eu-central-1",
             "service": "queue"

--- a/components/ip-addresses/kbc-public-ip.json
+++ b/components/ip-addresses/kbc-public-ip.json
@@ -1,6 +1,6 @@
 {
-    "syncToken": "1496657321",
-    "createDate": "2018-09-14-10-08-39",
+    "syncToken": "1675843081",
+    "createDate": "2023-02-08",
     "prefixes": [
         {
             "ipPrefix": "34.224.0.188/32",

--- a/components/ip-addresses/kbc-public-ip.json
+++ b/components/ip-addresses/kbc-public-ip.json
@@ -90,30 +90,6 @@
             "ipPrefix": "40.127.144.42/32",
             "vendor": "azure",
             "region": "north-europe",
-            "service": "syrup"
-        },
-        {
-            "ipPrefix": "20.82.252.94/32",
-            "vendor": "azure",
-            "region": "north-europe",
-            "service": "syrup"
-        },
-        {
-            "ipPrefix": "20.82.252.129/32",
-            "vendor": "azure",
-            "region": "north-europe",
-            "service": "syrup"
-        },
-        {
-            "ipPrefix": "20.82.252.124/32",
-            "vendor": "azure",
-            "region": "north-europe",
-            "service": "syrup"
-        },
-        {
-            "ipPrefix": "40.127.144.42/32",
-            "vendor": "azure",
-            "region": "north-europe",
             "service": "queue"
         },
         {

--- a/components/ip-addresses/kbc-public-ip.json
+++ b/components/ip-addresses/kbc-public-ip.json
@@ -22,9 +22,9 @@
         },
         {
             "ipPrefix": "149.72.196.5/32",
-            "vendor": "sendgrid",
+            "vendor": "aws",
             "region": "us-east-1",
-            "service": "syrup"
+            "service": "email-delivery"
         },
         {
             "ipPrefix": "34.203.87.137/32",
@@ -41,12 +41,6 @@
         {
             "ipPrefix": "52.20.72.254/32",
             "vendor": "aws",
-            "region": "us-east-1",
-            "service": "queue"
-        },
-        {
-            "ipPrefix": "149.72.196.5/32",
-            "vendor": "sendgrid",
             "region": "us-east-1",
             "service": "queue"
         },
@@ -76,15 +70,9 @@
         },
         {
             "ipPrefix": "149.72.196.5/32",
-            "vendor": "sendgrid",
+            "vendor": "aws",
             "region": "eu-central-1",
-            "service": "syrup"
-        },
-        {
-            "ipPrefix": "149.72.196.5/32",
-            "vendor": "sendgrid",
-            "region": "eu-central-1",
-            "service": "queue"
+            "service": "email-delivery"
         },
         {
             "ipPrefix": "40.127.144.42/32",
@@ -112,9 +100,9 @@
         },
         {
             "ipPrefix": "149.72.196.5/32",
-            "vendor": "sendgrid",
+            "vendor": "azure",
             "region": "north-europe",
-            "service": "queue"
+            "service": "email-delivery"
         }
     ]
 }


### PR DESCRIPTION
FIXES: https://keboola.atlassian.net/browse/ST-381

Aktualizace IP adres a pofixování současného stavu:
- Odstranění nepoužívanách IPS, nově se pak přidávají jako odchozí pro QV2
- Sjednoceni json souborů - nebyly stejné
- Oddelění IP adres pro legacy QV1 do samotných sekcí
- Odstraněný syrup pro Azure NE
- Označení email outbound IP adres a v json souborech uvedeno jako `email-delivery` služba
- Přidání nových IP adres, zatím přes ně nejde traffic. Bude k tomu blog post, validace, CSM, emaily atd... Kdo teď ale bude nově nastavovat pravidla firewall rovnou už nastaví všechny a bude to mít ready.

Zkouknou by mohlo jít lépe po commitech. Ty samotné IP https://keboola.atlassian.net/wiki/spaces/KB/pages/2880503825/Outbound+IPs jsem několikrát kontroloval tady i oproti AWS a mělo by to být ok. Do jsonů jsem to generoval ze seznamu.