### PR TITLE
PST-374 Remove Python version from docs

### DIFF
--- a/transformations/python-plain/index.md
+++ b/transformations/python-plain/index.md
@@ -12,8 +12,8 @@ faster to do in [SQL Transformations](/transformations/#backends).
 
 ## Environment
 The Python script is running in an isolated [environment](https://developers.keboola.com/extend/#component).
-The current Python version is **3.8.5**. The Python version is updated regularly, few weeks after the official release.
-The update is always announced on the [status page](https://status.keboola.com/).
+The Python version is updated regularly, few weeks after the official release. The update is always announced on the
+[status page](https://status.keboola.com/).
 
 ### Memory and Processing Constraints
 A Python transformation has a limit of 8GB of allocated memory and the maximum running time is 6 hours.

--- a/transformations/python/index.md
+++ b/transformations/python/index.md
@@ -15,8 +15,8 @@ Common data operations like joining, sorting, or grouping are still easier and f
 ## Environment
 
 The Python script is running in an isolated [Docker environment](https://developers.keboola.com/integrate/docker-bundle/).
-The current Python version is **3.8.5**. The Python version is updated regularly, few weeks after the official release.
-The update is always announced on the [status page](http://status.keboola.com/).
+The Python version is updated regularly, few weeks after the official release. The update is always announced on the
+[status page](http://status.keboola.com/).
 
 When we update the Python version, we offer --- for a limited time --- the option to switch to the previous version. You can
 switch the version in the transformation detail by clicking on the `Change Backend` label:
@@ -205,4 +205,3 @@ with open('/data/in/tables/source.csv', mode='rt', encoding='utf-8') as in_file,
 
 The `kbc` dialect is automatically available in the transformation environment. If you want it in your local environment,
 it is defined as `csv.register_dialect('kbc', lineterminator='\n', delimiter = ',', quotechar = '"')`.
-


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PST-374

Zkusil jsme par random hledani a nasle jen tyhle dva vyskyty. V developer docs jsme nenasel nic.

Zvazoval jsme jeste ten link, co si zminoval v issue, ale nakonec jsem se rozhodl ho tma nedavat:
* je ruzny pro kazdy stack a i kdyz je to ted stejne, do budoucna se ty verze muzou lisit (tyicky treba pro single-tenanty)
* vycist z toho JSON co hledas neni na prvni dobrou uplne snadne a nez to tam popisovat, je IMHO jednodussi se podivat nomrlane do projektu, co vidis v UI