### PR TITLE
Build - Use official AWS image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     command: jekyll serve --watch -H 0.0.0.0 --force_polling
 
   aws:
-    image: quay.io/keboola/aws-cli
+    image: public.ecr.aws/aws-cli/aws-cli:latest
     volumes:
       - ./:/code
     working_dir: /code


### PR DESCRIPTION
<!-- if proofreading is needed, create issue in PROOF project, optionally link also other issues
    if not, ask someone for review, if you are unsure who, ask hhanova
-->

Jira issue(s): https://keboola.atlassian.net/browse/ST-1860

Changes:

- We were using old docker image for AWS cli build. It stopped working after github upgraded Docker version on github actions. Fixing by using official AWS cli image.
