### PR TITLE
Notice about keboola.ex-email-attachments being available only on certain stacks

### DIFF
--- a/components/extractors/communication/email-attachments/index.md
+++ b/components/extractors/communication/email-attachments/index.md
@@ -16,6 +16,11 @@ Tables only get imported with the data source connector running. The import is *
 being sent or received. When running, the data source connector imports all emails received since its previous run.
 Therefore, it is a good idea to set up the data source connector in a [**scheduled** orchestration](/orchestrator/running/#time-schedule).
 
+<div class="alert alert-warning">
+    <strong>Warning:</strong>
+    This component is available only on AWS multitenant stacks <a href="https://connection.keboola.com">connection.keboola.com</a> and <a href="https://connection.eu-central-1.keboola.com">connection.eu-central-1.keboola.com</a>
+</div>
+
 ## Configuration
 [Create a new configuration](/components/#creating-component-configuration) of the **Email Attachments** data source connector.
 Each configuration corresponds to a single target email address. If you need 


### PR DESCRIPTION
Based on comments in https://keboola.atlassian.net/browse/SUPPORT-8206

Changes:
- Notice about keboola.ex-email-attachments being available only on certain stacks

![image](https://github.com/user-attachments/assets/11d1c6d1-5ce1-47cb-b913-bdcd3efc19d8)

