### PR TITLE
Add Maintenance section

### DIFF
--- a/management/index.md
+++ b/management/index.md
@@ -55,3 +55,10 @@ It is possible to entirely [delete your project](/management/project/delete/).
 ### Keboola Support
 There are multiple [ways to obtain support](/management/support/) from our technical staff.
 To solve your problem or to gain context, they may join your project when requested.
+
+### Maintenance
+Keboola performs scheduled maintenance from time to time to keep things running smoothly. This takes place on Saturdays between 6:00 AM and 7:00 AM UTC and won’t happen more than once every 30 days. We make every effort to minimize any disruption during this period, but to avoid any potential interruptions, we recommend not scheduling critical jobs/flows during this maintenance window.
+
+If maintenance is needed outside of the regular window, we’ll post an announcement at least 48 hours in advance on our [status page](https://status.keboola.com/), unless we’ve agreed on a different way to notify you.
+
+To check how the platform is doing at any moment, visit [stats.keboola.com](http://stats.keboola.com/) or use an alternative tracking method if one has been arranged with you.


### PR DESCRIPTION
Added Maintenance section at the end of Management page


<!-- briefly describe what are you changing and why -->

Changes:

- added section on Maintenance window to Management docs, as we need to reference it Premium SLA addon and MSA

---

<!-- provide additional notes -->
Context:
- this is [convo with Najlos](https://keboolaglobal.slack.com/archives/C052Y7MPDL3/p1744007550917509?thread_ts=1742470958.917619&cid=C052Y7MPDL3 ) for context on maintenance window
- this is [convo](https://keboolaglobal.slack.com/archives/C055K9CRFDX/p1745483457099089?thread_ts=1744015311.863859&cid=C055K9CRFDX) where we agreed on including maintenance reference in the docs