### PR TITLE
Update default.html

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -129,12 +129,11 @@
  	}
 </style>
 <!-- End KAI chatbot -->
-<script> // prefil env checkbox for Atlassian issue collector
+<script> 
 window.ATL_JQ_PAGE_PROPS = {
   '712ca69e': {
     fieldValues: {
-      recordWebInfo: '1', // field Name
-      recordWebInfoConsent: ['1'] // field Id
+      customfield_10325: window.location.href // track submission URL for Atlassian issue collector
     }
   }
 };


### PR DESCRIPTION
Saving URL from which the Documentation feedback is submitted, into an already existing field instead of a default system one.
