### PR TITLE
Saving URL for doc feedback to different custom field

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -133,7 +133,7 @@
 window.ATL_JQ_PAGE_PROPS = {
   '712ca69e': {
     fieldValues: {
-      customfield_10325: window.location.href // track submission URL for Atlassian issue collector
+      customfield_10330: window.location.href // track submission URL for Atlassian issue collector
     }
   }
 };


### PR DESCRIPTION
Saving URL for doc feedback to different custom field - into context directly instead of Keboola Platform URL
