### PR TITLE
Update integration instructions in index.md to specify navigation pat…

### DIFF
--- a/ai/mcp-server/index.md
+++ b/ai/mcp-server/index.md
@@ -53,7 +53,7 @@ For other options of local deployments see the [Developers Documentation](https:
 <p>These steps must be done by a Claude organization owner or primary owner, or on either a Claude Pro or Claude Max plan. The added integration will be available to all users in the Claude organization, but each user will still be required to authenticate themselves separately.</p>
 </div>
 
-- Go to [Settings > Integrations](https://claude.ai/settings/integrations)
+- Go to [Settings > Claude settings Configure > Integrations](https://claude.ai/settings/integrations)
 - Click the **"Add more"** button
 - Give the integration a name (Keboola) and paste in your Integration URL
   - `https://mcp.<YOUR_REGION>.keboola.com/sse`


### PR DESCRIPTION
# Fix Claude Settings Navigation Path in MCP Server Documentation

## Summary
Updates the Claude integration setup instructions to reflect the correct navigation path in Claude's interface.

## Changes
- **File**: `ai/mcp-server/index.md`
- **Change**: Updated navigation path from `Settings > Integrations` to `Settings > Claude settings Configure > Integrations`

## Problem
The current documentation shows an incorrect navigation path for accessing Claude's integrations settings. Users following the existing instructions would not be able to locate the correct settings page.

## Solution
Updated the documentation to reflect the actual navigation path in Claude's current interface, ensuring users can successfully configure their Keboola MCP integration. 