### PR TITLE
Updated Project Settings page 

### DIFF
--- a/ai/mcp-server/index.md
+++ b/ai/mcp-server/index.md
@@ -39,7 +39,7 @@ Keboola MCP Server is hosted on every multi-tenant stack and supports OAuth auth
 In case your AI assistant supports remote connection, you can connect to Keboola's MCP Server by following these steps:
 
 1. Obtain the remote server URL of the stack `https://mcp.<YOUR_REGION>.keboola.com/sse`.
-   - You can find the url in your Keboola [project settings](/management/project/), e.g. navigate to `Users & Settings` > `MCP Server`
+   - You can find the url in your Keboola [Project Settings](/management/project/) under the tab `MCP Server`
      - In there you can also find specific instructions for various clients.
 2. Copy the server URL and paste it into your AI assistant's settings.
 3. Once you save the settings and refresh your AI assistant, you will be prompted to authenticate with your Keboola account and select the project you want to connect to.

--- a/management/project/index.md
+++ b/management/project/index.md
@@ -6,17 +6,15 @@ permalink: /management/project/
 * TOC
 {:toc}
 
-The project settings page provides general information about your project.
-To access it, click the **Users & Settings** link in the top menu:
+The Project Settings page provides general information about your project.
+To access it, click your avatar icon at the upper right corner on any page in Keboola platform and select **Project Settings** from the dropdown menu.
 
-{: .image-popup}
-![Screenshot - Project Settings](/management/project/settings.png)
+The Project Settings page shows important properties of your project, such as:
 
-The settings page shows important properties of your project, such as:
-
+### 1 Project Details
 - Expiration
 - Type of project
-- Monthly fee
+- Storage type and data retention setting
 - Data retention for [time travel](/storage/tables/backups/)
 - Region -- physical location of the project data; it corresponds to an
 [Amazon Region identifier](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions).
@@ -28,3 +26,23 @@ You can also
 - [export all project data](/management/project/export/).
 - [migrate project to another region](/management/project/migration/)
 - [delete the project](/management/project/delete/).
+
+### 2 Users
+The User Settings page in the Keboola platform serves as a centralized location where you can review users that have been invited into the project, their authentication method and rights. From this page you can also invite new users or remove the current ones. For more detailed information go to [Users](/management/project/users).
+
+### 3 API Tokens
+The API Tokens section in the Keboola platform is used to manage programmatic access to a project via the Keboola Storage API. For more detailed information go to [Tokens](/management/project/tokens).
+
+### 4 CLI Sync
+The CLI Sync section is used to set up and manage synchronization between the Keboola platform and your local development environment using the Keboola CLI (KBC CLI). It allows you to securely connect CLI-based tools to a specific project, enabling actions like pulling configurations, pushing changes, or running jobs programmatically. 
+
+If you need to setup your Keboola CLI, simply follow the instructions displayed on this page. For more detailed information go to the [Developer documentation](https://developers.keboola.com/cli/).
+
+### 5 Features
+The Features section in the Keboola UI is used to toggle project-specific feature flags. It allows project admins to enable or disable experimental, beta, or advanced platform capabilities that are not generally available by default. 
+
+### 6 AI Rules
+The AI Rules section allows users to define specific instructions for AI functionality within Keboola platform. For more details go to [AI Rules](/management/project/ai-rules).
+
+### 7 MCP Server
+MCP Server section contains step-by-step instructions that will help you easily set up a connection between your AI Agent and Keboola platform to operate your data using just prompts. For more details go to [MCP Server](/ai/mcp-server).


### PR DESCRIPTION
Project Settings was outdated. Updated and added the context of CLI and MCP Server. 
Storage token changed to keboola api token (as we do not talk about storage token anywhere in the Docs. 
Fixed route to Project Settings in the MCP Server page....