### PR TITLE
Add Discord link to MCP section

### DIFF
--- a/ai/mcp-server/index.md
+++ b/ai/mcp-server/index.md
@@ -122,6 +122,8 @@ For CLI control, dev environments, or contributing to the MCP Server, check out 
 Need help or want to contribute? [Open an issue on GitHub](https://github.com/keboola/mcp-server/issues/new) to report bugs, request features, or suggest improvements.
 We’d love your ideas, fixes, and feedback to make MCP even better.
 
+Feel free to reach out to us on our [Discord](https://discord.gg/keboola) anytime — we're here to help!
+
 <div class="alert alert-warning">
 <p>Don't forget to give us a <a href="https://github.com/keboola/mcp-server">star on GitHub!</a> </p>
 </div>


### PR DESCRIPTION
Slack ref.: https://keboolaglobal.slack.com/archives/C08SWTN0QSV/p1749681437720999?thread_ts=1749673620.444969&cid=C08SWTN0QSV

Changes:

- Add Discord link to MCP section
