### PR TITLE
Update Keboola status links

### DIFF
--- a/404.md
+++ b/404.md
@@ -14,7 +14,7 @@ sitemap: false
 If you are looking for some other stuff that does not exist, you might want to visit:
 
 - [connection.keboola.com](https://connection.keboola.com) -- for logging in into Keboola
-- [status.keboola.com](https://status.keboola.com/) -- for getting Keboola Status updates (service status and changelog); we recommend subscribing to the feed or monitoring it in a Slack channel to keep up to date.
+- [keboolastatus.com](https://keboolastatus.com/) -- for getting Keboola Status updates (service status and changelog); we recommend subscribing to the feed or monitoring it in a Slack channel to keep up to date.
 - [help.keboola.com](https://help.keboola.com) -- for general help with using Keboola
 - [developers.keboola.com](https://developers.keboola.com) -- for developing a Keboola extension
 - [blog.keboola.com](https://blog.keboola.com/) -- something to read for data analysts

--- a/index.md
+++ b/index.md
@@ -30,7 +30,7 @@ Rest assured, we're here to support you whenever needed. Reach out via email at 
 - [Release notes](https://changelog.keboola.com/) 
 
 ## Resources
-- [status.keboola.com](http://status.keboola.com/) – get Keboola status updates (we recommend subscribing to the feed)
+- [keboolastatus.com](https://keboolastatus.com/) – get Keboola status updates (we recommend subscribing to the feed)
 - [www.keboola.com](https://www.keboola.com/) – our main web page
 - [blog.keboola.com](https://blog.keboola.com/) – something to read for data analysts
 - [500.keboola.com](https://500.keboola.com/) – something to read for tech geeks

--- a/management/index.md
+++ b/management/index.md
@@ -59,6 +59,7 @@ To solve your problem or to gain context, they may join your project when reques
 ### Maintenance
 Keboola performs scheduled maintenance from time to time to keep things running smoothly. This takes place on Saturdays between 6:00 AM and 7:00 AM UTC and won’t happen more than once every 30 days. We make every effort to minimize any disruption during this period, but to avoid any potential interruptions, we recommend not scheduling critical jobs/flows during this maintenance window.
 
-If maintenance is needed outside of the regular window, we’ll post an announcement at least 48 hours in advance on our [status page](https://status.keboola.com/), unless we’ve agreed on a different way to notify you.
+If maintenance is needed outside of the regular window, we’ll post an announcement at least 48 hours in advance on our [status page](https://keboolastatus.com/), unless we’ve agreed on a different way to notify you.
 
 To check how the platform is doing at any moment, visit [stats.keboola.com](http://stats.keboola.com/) or use an alternative tracking method if one has been arranged with you.
+

--- a/transformations/python-plain/index.md
+++ b/transformations/python-plain/index.md
@@ -15,7 +15,7 @@ faster to do in [SQL Transformations](/transformations/#backends).
 ## Environment
 The Python script is running in an isolated [environment](https://developers.keboola.com/extend/#component).
 The Python version is updated regularly, few weeks after the official release. The update is always announced on the
-[status page](https://status.keboola.com/).
+[status page](https://keboolastatus.com/).
 
 ### Memory and Processing Constraints
 A Python transformation has a limit of 8GB of allocated memory and the maximum running time is 6 hours.


### PR DESCRIPTION
## Release Notes 

Change links from status.keboola.com to keboolastatus.com.

Implements Implements https://keboola.atlassian.net/browse/ST-3331

## Plans for customer communication
None.

## Impact analysis
Multiple link changes

## Change type
Link URLs

## Justification
New status page.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.