### PR TITLE
docs: promote telemetry tables to project mode, add kbc_sql_workspace, deprecate kbc_workspace

### DIFF
--- a/_data/telemetry_tables.yml
+++ b/_data/telemetry_tables.yml
@@ -1168,7 +1168,7 @@ tables:
   # ===================== ACTIVITY CENTER MODE =====================
 
   - id: kbc_bucket
-    mode: activity_center
+    mode: project
     description: "This table shows data about the current state of storage buckets."
     is_full_load: true
     note: "The table is always extracted in full."
@@ -1540,7 +1540,7 @@ tables:
         example: "`[_internal] Daily Scheduler`"
 
   - id: kbc_table
-    mode: activity_center
+    mode: project
     description: "This table shows data about the current state of storage [tables](/storage/tables/)."
     is_full_load: true
     note: "The table is always extracted in full."
@@ -2029,7 +2029,7 @@ tables:
     mode: activity_center
     description: "This table shows data about existing [workspaces](/workspace/). Unlike SQL and Data Science sandboxes, this table includes all workspaces of the project (i.e., those created by transformations)."
     is_full_load: true
-    note: "The table is always extracted in full."
+    note: "**DEPRECATING** – This table is being replaced by `kbc_sql_workspace`. The table is always extracted in full."
     columns:
       - name: kbc_workspace_id
         pk: true
@@ -2094,6 +2094,64 @@ tables:
       - name: workspace_schema
         description: "Schema name"
         example: "`WORKSPACE_985088174`"
+
+  - id: kbc_sql_workspace
+    mode: project
+    description: "This table shows data about SQL [workspaces](/workspace/) provisioned via configurations. It replaces `kbc_workspace` for SQL-based workspace tracking."
+    is_full_load: true
+    note: "The table is always extracted in full."
+    columns:
+      - name: kbc_sql_workspace_id
+        pk: true
+        description: "Unique SQL workspace identifier"
+        example: "`985088171_kbc-us-east-1`"
+      - name: kbc_project_id
+        fk: kbc_project
+        description: "Foreign key to the Keboola project"
+        example: "`7880_kbc-us-east-1`"
+      - name: workspace_creator
+        description: "Creator of the workspace"
+        example: "`John Doe`"
+      - name: workspace_created
+        description: "Datetime when the workspace was created"
+        example: "`2023-06-13 20:41:42.268`"
+      - name: workspace_type
+        description: "Backend type of the workspace"
+        example: "`snowflake`"
+      - name: kbc_token_id
+        fk: kbc_token
+        description: "Foreign key to the Keboola token that created or owns the workspace"
+        example: "`287689_kbc-us-east-1`"
+      - name: kbc_token_name
+        description: "Name of the token that created or owns the workspace"
+        example: "`john.doe@keboola.com`"
+      - name: workspace_deleted
+        description: "Datetime when the workspace was deleted (empty if still active)"
+        example: "`2023-07-18 10:20:56.384`"
+      - name: workspace_updated
+        description: "Datetime when the workspace was last updated"
+        example: "`2023-07-12 12:01:24.181`"
+      - name: kbc_workspace_name
+        description: "Name of the workspace (derived from component configuration)"
+        example: "`My Workspace`"
+      - name: kbc_configuration_id
+        description: "Identifier of the configuration that created this workspace"
+        example: "`610931033`"
+      - name: workspace_database
+        description: "Database name of the workspace"
+        example: "`SAPI_1234`"
+      - name: workspace_schema
+        description: "Schema name of the workspace"
+        example: "`WORKSPACE_985088174`"
+      - name: backend_size
+        description: "Backend size of the workspace"
+        example: "`small`"
+      - name: read_only_storage_access
+        description: "Flag indicating if the workspace has read-only storage access (`true`, `false`)"
+        example: "`true`"
+      - name: workspace_shared
+        description: "Flag indicating if the workspace is shared with other users (`true`, `false`)"
+        example: "`true`"
 
   - id: kbc_workspace_event
     mode: activity_center
@@ -2166,7 +2224,7 @@ tables:
         example: "`[_internal] main scheduler`"
 
   - id: kbc_data_app
-    mode: activity_center
+    mode: project
     description: "This table lists the [apps](/data-apps/)."
     is_full_load: false
     columns:
@@ -2409,6 +2467,10 @@ relationships:
     label: "has workspaces"
     type: one-to-many
   - from: kbc_project
+    to: kbc_sql_workspace
+    label: "has sql workspaces"
+    type: one-to-many
+  - from: kbc_project
     to: kbc_workspace_event
     label: "has workspace events"
     type: one-to-many
@@ -2575,6 +2637,10 @@ relationships:
   - from: kbc_token
     to: kbc_workspace
     label: "creates workspaces"
+    type: one-to-many
+  - from: kbc_token
+    to: kbc_sql_workspace
+    label: "creates sql workspaces"
     type: one-to-many
   - from: kbc_token
     to: kbc_trigger

--- a/_data/telemetry_tables.yml
+++ b/_data/telemetry_tables.yml
@@ -2134,8 +2134,9 @@ tables:
         description: "Name of the workspace (derived from component configuration)"
         example: "`My Workspace`"
       - name: kbc_configuration_id
-        description: "Identifier of the configuration that created this workspace"
-        example: "`610931033`"
+        fk: kbc_component_configuration
+        description: "Foreign key to the component configuration that created this workspace"
+        example: "`580_kbc-us-east-1_keboola.sandboxes_610931033`"
       - name: workspace_database
         description: "Database name of the workspace"
         example: "`SAPI_1234`"

--- a/_data/telemetry_tables.yml
+++ b/_data/telemetry_tables.yml
@@ -2136,10 +2136,6 @@ tables:
       - name: kbc_configuration_id
         description: "Identifier of the configuration that created this workspace"
         example: "`610931033`"
-      - name: kbc_component_id
-        fk: kbc_component_configuration
-        description: "Foreign key to the component configuration that owns this workspace"
-        example: "`keboola.sandboxes_kbc-us-east-1`"
       - name: workspace_database
         description: "Database name of the workspace"
         example: "`SAPI_1234`"

--- a/_data/telemetry_tables.yml
+++ b/_data/telemetry_tables.yml
@@ -2136,6 +2136,10 @@ tables:
       - name: kbc_configuration_id
         description: "Identifier of the configuration that created this workspace"
         example: "`610931033`"
+      - name: kbc_component_id
+        fk: kbc_component_configuration
+        description: "Foreign key to the component configuration that owns this workspace"
+        example: "`keboola.sandboxes_kbc-us-east-1`"
       - name: workspace_database
         description: "Database name of the workspace"
         example: "`SAPI_1234`"

--- a/_data/telemetry_tables.yml
+++ b/_data/telemetry_tables.yml
@@ -2133,7 +2133,7 @@ tables:
       - name: kbc_workspace_name
         description: "Name of the workspace (derived from component configuration)"
         example: "`My Workspace`"
-      - name: kbc_configuration_id
+      - name: kbc_component_configuration_id
         fk: kbc_component_configuration
         description: "Foreign key to the component configuration that created this workspace"
         example: "`580_kbc-us-east-1_keboola.sandboxes_610931033`"

--- a/_data/telemetry_tables.yml
+++ b/_data/telemetry_tables.yml
@@ -2029,7 +2029,7 @@ tables:
     mode: activity_center
     description: "This table shows data about existing [workspaces](/workspace/). Unlike SQL and Data Science sandboxes, this table includes all workspaces of the project (i.e., those created by transformations)."
     is_full_load: true
-    note: "**DEPRECATING** – This table is being replaced by `kbc_sql_workspace`. The table is always extracted in full."
+    note: "**DEPRECATING** – This table is being replaced by `kbc_sql_workspace` and `kbc_data_app`. The table is always extracted in full."
     columns:
       - name: kbc_workspace_id
         pk: true

--- a/_data/telemetry_tables.yml
+++ b/_data/telemetry_tables.yml
@@ -2098,8 +2098,7 @@ tables:
   - id: kbc_sql_workspace
     mode: project
     description: "This table shows data about SQL [workspaces](/workspace/) provisioned via configurations. It replaces `kbc_workspace` for SQL-based workspace tracking."
-    is_full_load: true
-    note: "The table is always extracted in full."
+    is_full_load: false
     columns:
       - name: kbc_sql_workspace_id
         pk: true

--- a/_data/telemetry_tables.yml
+++ b/_data/telemetry_tables.yml
@@ -91,7 +91,6 @@ tables:
     mode: project
     description: "This table lists the [configurations of components](/components/#creating-component-configuration) (e.g., a configuration of the AWS S3 data source connector)."
     is_full_load: true
-    note: "The table is always extracted in full."
     columns:
       - name: kbc_component_configuration_id
         pk: true
@@ -139,7 +138,7 @@ tables:
         example: "`This transformation put the data from customers into standardize format.`"
       - name: configuration_json
         description: "Complete JSON configuration of the component"
-        example: "`{\"parameters\":{\"id\":\"34289954\"}}`"
+        example: '`{"parameters":{"id":"34289954"}}`'
       - name: kbc_branch_id
         fk: kbc_branch
         description: "Foreign key to a Keboola branch"
@@ -241,7 +240,7 @@ tables:
         example: "`This part of transformation consolidate the data from various sources.`"
       - name: configuration_row_json
         description: "Complete JSON configuration row of the component"
-        example: "`{\"parameters\":{\"incremental\":false}}`"
+        example: '`{"parameters":{"incremental":false}}`'
       - name: token_id
         description: "Identifier of the token that created this version of the configuration row"
         example: "`241247`"
@@ -377,7 +376,7 @@ tables:
         example: "`410_kbc-eu-central-1_keboola.wr-google-sheets-259642632`"
       - name: kbc_component_configuration_row_id
         description: "An array where each element serves as a foreign key to a Keboola component configuration row. This array is populated as a result of filtering rows during the job execution. If the job runs with all rows (no filtering), the array remains empty."
-        example: "`[\"8765_kbc-us-east-1_keboola.ex-db-mysql_844500148_844500150\"]`"
+        example: '`["8765_kbc-us-east-1_keboola.ex-db-mysql_844500148_844500150"]`'
       - name: kbc_branch_id
         fk: kbc_branch
         description: "Foreign key to the Keboola branch"
@@ -518,13 +517,13 @@ tables:
         example: "`query_data`"
       - name: tool_arguments
         description: "JSON array of key-value pairs representing the arguments passed to the tool call"
-        example: "`[{\"key\":\"bucket_ids\",\"value\":\"[]\"}]`"
+        example: '`[{"key":"bucket_ids","value":"[]"}]`'
       - name: duration
         description: "Duration of the tool call execution in seconds"
         example: "`3`"
       - name: message
         description: "Result message -- a success confirmation or the full error message for failed calls"
-        example: "`MCP tool \"query_data\" call succeeded.`"
+        example: '`MCP tool "query_data" call succeeded.`'
       - name: agent_type
         description: "Type of agent that made the call. Possible values: <br> `external` -- an external MCP client (Claude Desktop, Cursor, etc.), <br> `kai-assistant` -- the Keboola Kai assistant, <br> `ai-chat` -- the Keboola AI Chat"
         example: "`kai-assistant`"
@@ -785,7 +784,7 @@ tables:
         description: "Column used to filter rows of the source table"
         example: "`USER_ID`"
       - name: alias_filter_operator
-        description: "Type of the alias filter operator. Possible values: <br> `eq` -- SQL \"IN\" <br> `ne` -- SQL \"NOT IN\""
+        description: 'Type of the alias filter operator. Possible values: <br> `eq` -- SQL "IN" <br> `ne` -- SQL "NOT IN"'
         example: "`eq`"
       - name: alias_filter_value
         description: "Value the alias filter is filtering by"
@@ -1171,7 +1170,6 @@ tables:
     mode: project
     description: "This table shows data about the current state of storage buckets."
     is_full_load: true
-    note: "The table is always extracted in full."
     columns:
       - name: bucket_id
         description: "Storage bucket identifier"
@@ -1227,7 +1225,6 @@ tables:
     mode: activity_center
     description: "This table shows data about the current state of storage columns."
     is_full_load: true
-    note: "The table is always extracted in full."
     columns:
       - name: column_id
         description: "Storage column identifier"
@@ -1255,7 +1252,6 @@ tables:
     mode: activity_center
     description: "This table shows data about columns' metadata."
     is_full_load: true
-    note: "The table is always extracted in full."
     columns:
       - name: kbc_column_metadata_id
         pk: true
@@ -1292,7 +1288,6 @@ tables:
     mode: activity_center
     description: "This table shows data about particular phases of flows."
     is_full_load: true
-    note: "The table is always extracted in full."
     columns:
       - name: kbc_flow_phase_id
         pk: true
@@ -1320,7 +1315,6 @@ tables:
     mode: activity_center
     description: "This table shows data about flow tasks."
     is_full_load: true
-    note: "The table is always extracted in full."
     columns:
       - name: kbc_flow_task_id
         pk: true
@@ -1425,7 +1419,6 @@ tables:
     mode: activity_center
     description: "This table shows data subscriptions to notifications sent by Keboola (mostly flow notifications)."
     is_full_load: true
-    note: "The table is always extracted in full."
     columns:
       - name: kbc_notification_subscription_id
         pk: true
@@ -1496,7 +1489,6 @@ tables:
     mode: activity_center
     description: "This table shows data about configuration schedules."
     is_full_load: true
-    note: "The table is always extracted in full."
     columns:
       - name: kbc_schedule_id
         pk: true
@@ -1543,7 +1535,6 @@ tables:
     mode: project
     description: "This table shows data about the current state of storage [tables](/storage/tables/)."
     is_full_load: true
-    note: "The table is always extracted in full."
     columns:
       - name: kbc_project_table_id
         pk: true
@@ -1591,7 +1582,7 @@ tables:
         description: "Column used to filter rows of the source table"
         example: "`user_id`"
       - name: alias_filter_operator
-        description: "Type of the alias filter operator. Possible values: <br> `eq` -- SQL \"IN\" <br> `ne` -- SQL \"NOT IN\""
+        description: 'Type of the alias filter operator. Possible values: <br> `eq` -- SQL "IN" <br> `ne` -- SQL "NOT IN"'
         example: "`eq`"
       - name: alias_filter_value
         description: "Value the alias filter is filtering by"
@@ -1640,10 +1631,10 @@ tables:
         example: "`Imported table in.c-in_sh_kbc_internal.kbc_flow_task`"
       - name: params
         description: "Parameters of the event (JSON object)"
-        example: "`{\"importId\":\"985123712\",\"incremental\":true,\"source\":{\"dataObject\":\"out_kbc_flow_task\",\"type\":\"workspace\",\"tableName\":\"out_kbc_flow_task\",\"workspaceId\":\"985122240\"}}`"
+        example: '`{"importId":"985123712","incremental":true,"source":{"dataObject":"out_kbc_flow_task","type":"workspace","tableName":"out_kbc_flow_task","workspaceId":"985122240"}}`'
       - name: results
         description: "Results of the event (JSON object)."
-        example: "`{\"rowsCount\":\"272800\",\"sizeBytes\":15412736}`"
+        example: '`{"rowsCount":"272800","sizeBytes":15412736}`'
       - name: kbc_token_id
         fk: kbc_token
         description: "Foreign key to the Keboola token"
@@ -1660,7 +1651,6 @@ tables:
     mode: activity_center
     description: "This table shows data about metadata of the storage [tables](/storage/tables/)."
     is_full_load: true
-    note: "The table is always extracted in full."
     columns:
       - name: kbc_table_metadata_id
         pk: true
@@ -1691,7 +1681,6 @@ tables:
     mode: activity_center
     description: "This table shows data about the storage [tokens](/management/project/tokens/)."
     is_full_load: true
-    note: "The table is always extracted in full."
     columns:
       - name: kbc_token_id
         pk: true
@@ -1789,7 +1778,6 @@ tables:
     mode: activity_center
     description: "This table shows data about codes of [transformations](/transformations/)."
     is_full_load: true
-    note: "The table is always extracted in full."
     columns:
       - name: kbc_transformation_code_id
         pk: true
@@ -1814,7 +1802,6 @@ tables:
     mode: activity_center
     description: "This table shows data about inputs of [transformations](/transformations/)."
     is_full_load: true
-    note: "The table is always extracted in full."
     columns:
       - name: kbc_transformation_input_id
         pk: true
@@ -1845,13 +1832,12 @@ tables:
         example: "`eq`"
       - name: where_values
         description: "Column filter value (JSON array)"
-        example: "`[\"com-keboola-azure-north-europe\"]`"
+        example: '`["com-keboola-azure-north-europe"]`'
 
   - id: kbc_transformation_input_column
     mode: activity_center
     description: "This table shows data about input columns of [transformations](/transformations/). Available only for non-clone mappings."
     is_full_load: true
-    note: "The table is always extracted in full."
     columns:
       - name: kbc_transformation_input_column_id
         pk: true
@@ -1882,7 +1868,6 @@ tables:
     mode: activity_center
     description: "This table shows data about outputs of the [transformations](/transformations/)."
     is_full_load: true
-    note: "The table is always extracted in full."
     columns:
       - name: kbc_transformation_output_id
         pk: true
@@ -1907,7 +1892,7 @@ tables:
         example: "`out_kbc_data_science_sandbox`"
       - name: primary_key
         description: "Primary key of the table (JSON array)"
-        example: "`[\"kbc_data_science_sandbox_resume_id\",\"date\"]`"
+        example: '`["kbc_data_science_sandbox_resume_id","date"]`'
       - name: delete_where_column
         description: "Column used to identify records to delete before storage import"
         example: "`kbc_project_stack`"
@@ -1916,13 +1901,12 @@ tables:
         example: "`eq`"
       - name: delete_where_values
         description: "Column filter value (JSON array)"
-        example: "`[\"com-keboola-azure-north-europe\"]`"
+        example: '`["com-keboola-azure-north-europe"]`'
 
   - id: kbc_trigger
     mode: activity_center
     description: "This table shows data about [triggers](/components/applications/triggers/)."
     is_full_load: true
-    note: "The table is always extracted in full."
     columns:
       - name: kbc_trigger_id
         pk: true
@@ -1970,7 +1954,6 @@ tables:
     mode: activity_center
     description: "This table shows data about tables used to [trigger](/components/applications/triggers/) jobs."
     is_full_load: true
-    note: "The table is always extracted in full."
     columns:
       - name: kbc_trigger_table_id
         pk: true
@@ -2027,9 +2010,8 @@ tables:
 
   - id: kbc_workspace
     mode: activity_center
-    description: "This table shows data about existing [workspaces](/workspace/). Unlike SQL and Data Science sandboxes, this table includes all workspaces of the project (i.e., those created by transformations)."
+    description: "**DEPRECATING** – This table is being replaced by `kbc_sql_workspace` and `kbc_data_app`. \n\nThis table shows data about existing [workspaces](/workspace/). Unlike SQL and Data Science sandboxes, this table includes all workspaces of the project (i.e., those created by transformations)."
     is_full_load: true
-    note: "**DEPRECATING** – This table is being replaced by `kbc_sql_workspace` and `kbc_data_app`. The table is always extracted in full."
     columns:
       - name: kbc_workspace_id
         pk: true
@@ -2300,7 +2282,7 @@ tables:
         example: "`streamlit write only-token`"
       - name: params
         description: "Parameters of the event (JSON object)"
-        example: "`{\"event_type\":\"keboola_data_app_write\",\"event_job_id\":151808445362,\"event_application\":\"Unknown\",\"time\":\"2024-11-18 16:15:02\",\"user\":\"Unknown\"}`"
+        example: '`{"event_type":"keboola_data_app_write","event_job_id":151808445362,"event_application":"Unknown","time":"2024-11-18 16:15:02","user":"Unknown"}`'
 
 relationships:
   # Organization -> Project

--- a/components/extractors/other/telemetry-data/telemetry-data.md
+++ b/components/extractors/other/telemetry-data/telemetry-data.md
@@ -44,21 +44,22 @@ window.TELEMETRY_DIAGRAM = {{ site.data.telemetry_tables | jsonify }};
 ## Project Mode Tables
 The extracted tables provide you with information about your buckets, configurations, branches, jobs, AI agent and MCP interactions, sandboxes, projects, users, and security events.
 
-{% for table in site.data.telemetry_tables.tables %}{% if table.mode == "project" %}
+{% assign sorted_tables = site.data.telemetry_tables.tables | sort: "id" %}
+{% for table in sorted_tables %}{% if table.mode == "project" %}
 {% include telemetry-table.html table=table %}
 {% endif %}{% endfor %}
 
 ## Organization Mode Tables
 In addition to the tables provided to you by [Project Mode](#project-mode-tables), this mode adds information about your organizations, outlines the limits of your contracts, and includes a table with usage metrics. This table can be used as a common dimension for both contract limits and metric values.
 
-{% for table in site.data.telemetry_tables.tables %}{% if table.mode == "organization" %}
+{% for table in sorted_tables %}{% if table.mode == "organization" %}
 {% include telemetry-table.html table=table %}
 {% endif %}{% endfor %}
 
 ## Activity Center Mode Tables
 In addition to the tables provided to you by [Organization Mode](#organization-mode-tables), this mode adds information about columns, flows, notifications, schedules, storage metadata, tokens, transformations, triggers, user activity, and workspaces.
 
-{% for table in site.data.telemetry_tables.tables %}{% if table.mode == "activity_center" %}
+{% for table in sorted_tables %}{% if table.mode == "activity_center" %}
 {% include telemetry-table.html table=table %}
 {% endif %}{% endfor %}
 


### PR DESCRIPTION
Jira issue(s): N/A

<!-- briefly describe what are you changing and why -->

Changes:

- **Promoted 3 tables from Activity Center to Project mode**: `kbc_bucket`, `kbc_table`, `kbc_data_app` — these are now available to all customers in project-level telemetry extraction, not just Activity Center subscribers.
- **Added new `kbc_sql_workspace` table** (project mode, full load) with 16 columns matching the L1.5 pipeline output. This table replaces `kbc_workspace` for SQL-based workspace tracking.
- **Added DEPRECATING note to `kbc_workspace`** pointing users to `kbc_sql_workspace` and `kbc_data_app` as replacements.
- **Added relationships** for `kbc_sql_workspace`: `kbc_project → kbc_sql_workspace` and `kbc_token → kbc_sql_workspace`.

---

Companion to pipeline changes in [telemetry-billing-gcp#297](https://github.com/keboola/telemetry-billing-gcp/pull/297).

**Review notes:**
- The promoted tables still sit under the `# ACTIVITY CENTER MODE` YAML comment but have `mode: project` — the Jekyll template renders by the `mode` field so this is cosmetic only. Consider whether reordering is desired.
- Verify `kbc_sql_workspace` column list matches the actual pipeline output (sourced from the L1.5 CREATE TABLE statement).

Link to Devin session: https://app.devin.ai/sessions/25431bc4113c41fe91e2e63b5491ef13
Requested by: @DasaDama