### PR TITLE
docs: alias tables now accessible via read-only storage (persisted alias views)

### DIFF
--- a/catalog/index.md
+++ b/catalog/index.md
@@ -53,7 +53,7 @@ There are some constraints to how shared buckets can be used:
 
 - Source and destination projects must belong to the same organization (and region).
 - To manage shared buckets, your user account must be an [organization member](/management/organization/) or a project administrator with the [share role](/management/project/users/#user-roles) assigned.
-- [Table aliases](/storage/tables/#aliases) filtered by a condition are not shared.
+- [Table aliases](/storage/tables/#aliases) filtered by a condition are shared as database VIEWs with the filter enforced as a `WHERE` clause.
 - [Table aliases](/storage/tables/#aliases) without automatically synchronized columns are not shared.
 - Tables in linked buckets work like [aliases](/storage/tables/#aliases) — i.e., all tables are read-only in the destination project.
 - If your bucket is already linked in other projects, you cannot drop it. Nor can you drop any of its children, tables or columns.
@@ -110,7 +110,7 @@ create an [alias](/storage/tables/#aliases) of the table and set the shared buck
 
 2. Click **Create Alias**.
 
-3. **Select the shared bucket** as the destination. Ensure the alias has no filter and automatic synchronization of the columns enabled.
+3. **Select the shared bucket** as the destination. Ensure automatic synchronization of the columns is enabled.
 
 Once created in the shared bucket, the alias will immediately appear in all linked projects.
 

--- a/storage/tables/index.md
+++ b/storage/tables/index.md
@@ -35,6 +35,12 @@ Apart from actual tables, it is also possible to create aliases. They behave sim
 An alias does not contain any actual data; it is simply a link to some already existing data.
 Therefore, an alias cannot be written to, and its size does not count toward your project quota.
 
+Alias tables are automatically materialized as physical database VIEWs. This makes them fully accessible in workspaces and 
+transformations via [read-only storage access](/transformations/mappings/#read-only-input-mapping) — no input mapping configuration is required. 
+Filtered aliases are also supported; the filter condition is enforced as a `WHERE` clause in the VIEW. 
+In [linked buckets](/catalog/), alias VIEWs from the source project are automatically mirrored to the destination project, 
+making them immediately queryable there as well.
+
 To create an alias table, go to the table detail, click the three dots on the right side of the screen, and select the 'Create alias table' option.
 
 {: .image-popup}

--- a/transformations/mappings/index.md
+++ b/transformations/mappings/index.md
@@ -161,7 +161,7 @@ This function is automatically enabled in transformations.
 *Note: You must be using [new transformations](/transformations/#new-transformations) to see this feature.*
 
 When **read-only input mappings** are enabled, you automatically have read access to all buckets and tables in the project (this also applies to linked buckets).
-However, a **read-only input mapping** cannot access alias tables, because technically it is just a reference to an existing schema. However, you can still manually add tables to an input mapping.
+Alias tables are materialized as database VIEWs and are fully accessible via read-only input mappings — including filtered aliases and aliases from linked buckets.
    
 There is no need to set anything for a **read-only input mapping** in **transformations**, all tables in Storage are automatically accessible in the transformation.
 This also applies to linked buckets. *Note that buckets and tables belong

--- a/transformations/snowflake-plain/index.md
+++ b/transformations/snowflake-plain/index.md
@@ -249,7 +249,7 @@ SELECT
 
 For more information on how a **read-only input mapping** works, visit the [link](/transformations/mappings/#read-only-input-mapping).
 Buckets in Snowflake are represented by schemas. You can find all available schemas for your account by calling `SHOW SCHEMAS IN ACCOUNT;`. Each schema represents a bucket.
-However, a **read-only input mapping** cannot access alias tables, because technically it is just a reference to an existing schema.
+Alias tables are materialized as database VIEWs and are accessible via read-only input mappings — including filtered aliases and aliases from linked buckets.
 For a linked bucket, the schema is available in another database. That is, to access this linked bucket you have to include the database name of the project from which the bucket is linked. 
 For example, say your bucket `in.c-customers` is linked from bucket `in.c-crm-extractor` in project 123. You then need to reference the tables in the transformation like this: `"KEBOOLA_123"."in.c-crm-extractor"."my-table"`. 
 When developing the transformation code, it's easiest to create a workspace with **read-only input mappings** enabled and look directly in the database to find the correct database and schema names. 

--- a/workspace/index.md
+++ b/workspace/index.md
@@ -273,7 +273,7 @@ With **read-only input mappings** disabled, only tables listed in the input mapp
 ![Workspace - Create new workspace with Read Only](/workspace/create-new-ws-with-ro.png)
 
 So, if we enable this feature when we create a workspace, we can access individual tables in the workspace,
-without needing to define any tables in the input mapping. However, a **read-only input mapping** cannot access alias tables, because technically it is just a reference to an existing schema.
+without needing to define any tables in the input mapping. Alias tables are materialized as database VIEWs and are fully accessible via read-only input mappings — including filtered aliases.
 This also applies to linked buckets. *Note that buckets and tables belong to another project, so you must access, for example, the database of another project depending on the backend.
 For example, say your bucket `in.c-customers` is linked from bucket `in.c-crm-extractor` in project 123. You then need to reference the tables in the transformation like this: `"KEBOOLA_123"."in.c-crm-extractor"."my-table"`. When developing transformation code, it's easiest to create a workspace with **read-only input mappings** enabled and look directly in the database to find the correct database and schema names. 
 


### PR DESCRIPTION
## Summary

- **`storage/tables/index.md`** — Added explanation that alias tables are automatically materialized as database VIEWs, making them accessible in workspaces and transformations via read-only storage access without any input mapping configuration. Notes that filtered aliases are supported (WHERE clause enforced in the VIEW) and that alias VIEWs are mirrored to linked bucket projects.
- **`transformations/mappings/index.md`** — Removed the limitation stating read-only input mappings cannot access alias tables; replaced with positive statement that aliases (including filtered and linked-bucket aliases) are fully accessible.
- **`workspace/index.md`** — Same update as mappings — alias tables including filtered ones are accessible via read-only input mappings in workspaces.
- **`transformations/snowflake-plain/index.md`** — Updated the Bucket Objects for Read-Only Input Mapping section accordingly.
- **`catalog/index.md`** — Updated two places: (1) the sharing constraint now correctly states filtered aliases are shared as VIEWs with the WHERE clause enforced; (2) removed the "no filter" requirement from the "Adding new tables to an existing shared bucket" instructions.

## Context

Previously, alias tables were metadata-only — no physical database object existed, so they were invisible to workspaces, transformations using read-only input mapping, and linked bucket projects. With the Persisted Alias Views feature, every qualifying alias is automatically materialized as a database VIEW, making aliases first-class citizens in storage.

## Test plan

- [ ] Verify alias table is visible and queryable in a workspace via read-only storage access
- [ ] Verify filtered alias (e.g. `WHERE status = 'active'`) is accessible via read-only input mapping in a transformation
- [ ] Verify alias from a linked bucket is accessible in the destination project

🤖 Generated with [Claude Code](https://claude.com/claude-code)