### PR TITLE
docs: add deprecation banner to Templates and nest under Flows (Legacy)

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -97,60 +97,60 @@ items:
     items:
       - url: /flows/flows-legacy/
         title: Flows (Legacy)
-
-      - url: /flows/templates/
-        title: Templates
         items:
-          - url: /flows/templates/marketing-platforms/
-            title: Advertising Platforms
+          - url: /flows/templates/
+            title: Templates
+            items:
+              - url: /flows/templates/marketing-platforms/
+                title: Advertising Platforms
 
-          - url: /flows/templates/ai-sms-campaign/
-            title: AI SMS Campaign
+              - url: /flows/templates/ai-sms-campaign/
+                title: AI SMS Campaign
 
-          - url: /flows/templates/customer-relationship-management/
-            title: Customer Relationship Management
+              - url: /flows/templates/customer-relationship-management/
+                title: Customer Relationship Management
 
-          - url: /flows/templates/datahub/
-            title: DataHub
+              - url: /flows/templates/datahub/
+                title: DataHub
 
-          - url: /flows/templates/data-quality/
-            title: Data Quality
+              - url: /flows/templates/data-quality/
+                title: Data Quality
 
-          - url: /flows/templates/ecommerce/
-            title: eCommerce
+              - url: /flows/templates/ecommerce/
+                title: eCommerce
 
-          - url: /flows/templates/ecomm-kpi-dashboard/
-            title: eCommerce KPI Dashboard
+              - url: /flows/templates/ecomm-kpi-dashboard/
+                title: eCommerce KPI Dashboard
 
-          - url: /flows/templates/google-analytics4/
-            title: Google Analytics 4
+              - url: /flows/templates/google-analytics4/
+                title: Google Analytics 4
 
-          - url: /flows/templates/interactive-keboola-sheets/
-            title: Interactive Keboola Sheets
+              - url: /flows/templates/interactive-keboola-sheets/
+                title: Interactive Keboola Sheets
 
-          - url: /flows/templates/mailchimp/
-            title: Mailchimp
+              - url: /flows/templates/mailchimp/
+                title: Mailchimp
 
-          - url: /flows/templates/media-cashflow/
-            title: Media Cashflow
+              - url: /flows/templates/media-cashflow/
+                title: Media Cashflow
 
-          - url: /flows/templates/project-management/
-            title: Project Management
+              - url: /flows/templates/project-management/
+                title: Project Management
 
-          - url: /flows/templates/repository/
-            title: Repository
+              - url: /flows/templates/repository/
+                title: Repository
 
-          - url: /flows/templates/snowflake-security-checkup/
-            title: Snowflake Security Checkup
+              - url: /flows/templates/snowflake-security-checkup/
+                title: Snowflake Security Checkup
 
-          - url: /flows/templates/social-media-engagement/
-            title: Social Media Engagement
+              - url: /flows/templates/social-media-engagement/
+                title: Social Media Engagement
 
-          - url: /flows/templates/surveys/
-            title: Surveys
+              - url: /flows/templates/surveys/
+                title: Surveys
 
-          - url: /flows/templates/ua-and-ga4-comparison/
-            title: UA and GA4 Comparison
+              - url: /flows/templates/ua-and-ga4-comparison/
+                title: UA and GA4 Comparison
 
   - url: /data-apps/
     title: Apps

--- a/flows/flows-legacy/index.md
+++ b/flows/flows-legacy/index.md
@@ -12,8 +12,6 @@ permalink: /flows/flows-legacy/
 
 We're planning an automatic migration from Legacy Flows to [Flows](/flows/) to ensure a smooth transition without requiring manual intervention from users. This migration will preserve the logic, scheduling, and component configurations of existing flows while upgrading them to support conditional branching, retries, and other advanced features. In most cases, the migrated flows will look and behave the same — but with added flexibility under the hood.
 
-Legacy Flows and [Flows](/flows/) are not interchangeable. You cannot convert one to the other manually.
-
 * TOC
 {:toc}
 

--- a/flows/flows-legacy/index.md
+++ b/flows/flows-legacy/index.md
@@ -8,6 +8,12 @@ permalink: /flows/flows-legacy/
     <strong>Important:</strong> This is the legacy Flow Builder. It is being replaced by <a href="/flows/">Flows</a>, which offer conditional logic, branching, retries, and more robust error handling. We recommend using <a href="/flows/">Flows</a> for all new workflows. An automatic migration from legacy Flows to Flows is planned.
 </div>
 
+## Migration to Flows
+
+We're planning an automatic migration from Legacy Flows to [Flows](/flows/) to ensure a smooth transition without requiring manual intervention from users. This migration will preserve the logic, scheduling, and component configurations of existing flows while upgrading them to support conditional branching, retries, and other advanced features. In most cases, the migrated flows will look and behave the same — but with added flexibility under the hood.
+
+Legacy Flows and [Flows](/flows/) are not interchangeable. You cannot convert one to the other manually.
+
 * TOC
 {:toc}
 

--- a/flows/flows-legacy/index.md
+++ b/flows/flows-legacy/index.md
@@ -5,7 +5,7 @@ permalink: /flows/flows-legacy/
 
 <div class="alert alert-warning" role="alert">
     <i class="fas fa-exclamation-circle"></i>
-    <strong>Important:</strong> This is the legacy Flow Builder. It is being replaced by <a href="/flows/">Conditional Flows</a>, which offer conditional logic, branching, retries, and more robust error handling. We recommend using Conditional Flows for all new workflows. An automatic migration from legacy Flows to Conditional Flows is planned.
+    <strong>Important:</strong> This is the legacy Flow Builder. It is being replaced by <a href="/flows/">Flows</a>, which offer conditional logic, branching, retries, and more robust error handling. We recommend using <a href="/flows/">Flows</a> for all new workflows. An automatic migration from legacy Flows to Flows is planned.
 </div>
 
 * TOC

--- a/flows/flows-legacy/index.md
+++ b/flows/flows-legacy/index.md
@@ -12,6 +12,8 @@ permalink: /flows/flows-legacy/
 
 We're planning an automatic migration from Legacy Flows to [Flows](/flows/) to ensure a smooth transition without requiring manual intervention from users. This migration will preserve the logic, scheduling, and component configurations of existing flows while upgrading them to support conditional branching, retries, and other advanced features. In most cases, the migrated flows will look and behave the same — but with added flexibility under the hood.
 
+News and more information about the migration will be posted to our [changelog](https://changelog.keboola.com/).
+
 * TOC
 {:toc}
 

--- a/flows/index.md
+++ b/flows/index.md
@@ -14,7 +14,7 @@ Flows allow you to build automated data pipelines with conditional logic, branch
 
 ## Access Flows
 
-Navigate to **Flows > Conditional Flows > Create Flow**. After this step, you'll land directly in the Builder where you can start creating your first flow. Use the plus icon (+) to add different types of actions such as components, conditions, variables, notifications, and more - all of which are explained in detail later in this documentation.
+Navigate to **Flows > Create Flow**. You'll land directly in the Builder where you can start creating your first flow. Use the plus icon (+) to add different types of actions such as components, conditions, variables, notifications, and more — all of which are explained in detail later in this documentation.
 
 ## Build the Flow
 
@@ -22,9 +22,11 @@ Navigate to **Flows > Conditional Flows > Create Flow**. After this step, you'll
 
 - **Phases** group multiple tasks (components, variables, notifications).
 - **Tasks within a phase** run in parallel.
-- **After all tasks complete**, based on conditions it is determined which phase will be executed next.
+- **After all tasks in a phase complete**, based on conditions it is determined which phase will be executed next.
 - You can define **multiple condition rules** - only the first matched condition is executed.
 - **How to end a flow:** You can stop a flow at any point using the End Flow option in the ELSE path of a conditional condition. This is especially useful when none of your IF conditions are met and you want to avoid continuing to another phase.
+
+{% include warning.html content="If too many tasks are scheduled in a single phase, you may exceed the available [Storage job](/storage/jobs/) slots, causing delays in your flow's execution. Limiting the number of concurrent component jobs to 10 is recommended. The Keboola Support team can help you adjust parallel limits." %}
 
 ## Conditions
 
@@ -172,6 +174,19 @@ You can also create the notification inside of condition as a New Phase, name it
 {: .image-popup}
 ![](/flows/conditional-flows/notification-2.png)
 
+## Schedule and Automate
+
+Click on **Set Schedule** in your flow and select when you want the flow to run. You can select predefined intervals or set your own. Another option is to use triggers to initiate the run.
+
+**Scheduling:** Commonly, flows are set to run at specific times. To avoid busy periods in a shared environment, consider scheduling slightly off-peak for smoother execution.
+
+**Triggers:** Set flows to automatically start when certain Storage tables are updated (ideal for managing dependencies across projects). Your projects will stay synchronized and run efficiently.
+
+{: .image-popup}
+![Set Schedule](/flows/set-schedule.png)
+
+*Note on Triggers: If table updates happen during the cool-down period, the trigger is suppressed, but the tables are marked as ready. Therefore, if all configured tables are updated during the cool-down period, the flow is not scheduled at that time — but once the cool-down expires and any table is updated (causing the trigger to be evaluated), the system recognizes that all tables are already up to date and runs the flow immediately.*
+
 ## Check Run History
 
 Once your flow is running, you can track its progress and debug issues using the **All Runs** tab.
@@ -198,15 +213,11 @@ There are differences between Flows and Legacy Flows at the moment, see the tabl
 | Feature / Behavior | Flows                                           | Legacy Flows | Notes                                                                                                                |
 |-------------------|-------------------------------------------------------------|-------|----------------------------------------------------------------------------------------------------------------------|
 | Run Selected Tasks / Re-run Failed Tasks | 🚧 Not yet supported                               | ✅ Supported | Planned for GA. Workaround: duplicate the phase and skip conditionally. Set Retry.                                   |
-| Trigger Components (cross-project) | 🚧 Not yet supported                                         | ✅ Supported | Planned for Flows. You can't trigger another flow in Project B from Project A yet. |
+| Trigger Components (cross-project) | ✅ Supported                                         | ✅ Supported | Cross-project flow triggering is available. |
 | CLI Support | 🚧 Not yet supported                                          | ✅ Supported | Not yet available via Keboola CLI.                                                             |
-| Templates Support | 🚧 Not yet supported                                          | ✅ Supported | Not available yet.                                                                              |
 | "Continue on Failure" toggle | 🔁 Replaced by Conditions | ✅ Simple UI toggle | Failure handling is expressed through conditions, offering more flexibility. (e.g., if status == 'error' then...)                  |
 
 ## Migration
 
 We're planning an automatic migration from Legacy Flows to Flows to ensure a smooth transition without requiring manual intervention from users. This migration will preserve the logic, scheduling, and component configurations of existing flows while upgrading them to support conditional branching, retries, and other advanced features. In most cases, the migrated flows will look and behave the same - but with added flexibility under the hood.
 
-## How to disable Flows
-
-Go to **Project Settings -> Features -> Conditional Flows** - use toggle to disable the feature.

--- a/flows/index.md
+++ b/flows/index.md
@@ -204,20 +204,4 @@ You can use this overview to validate whether your conditions behaved as expecte
 {: .image-popup}
 ![](/flows/conditional-flows/all-runs.png)
 
-## Comparison with Legacy Flows
-
-Flows and [Legacy Flows](/flows/flows-legacy/) are not interchangeable. You cannot convert one to the other. A migration tool is being planned to help with this in the future.
-
-There are differences between Flows and Legacy Flows at the moment, see the table below for more information:
-
-| Feature / Behavior | Flows                                           | Legacy Flows | Notes                                                                                                                |
-|-------------------|-------------------------------------------------------------|-------|----------------------------------------------------------------------------------------------------------------------|
-| Run Selected Tasks / Re-run Failed Tasks | 🚧 Not yet supported                               | ✅ Supported | Planned for GA. Workaround: duplicate the phase and skip conditionally. Set Retry.                                   |
-| Trigger Components (cross-project) | ✅ Supported                                         | ✅ Supported | Cross-project flow triggering is available. |
-| CLI Support | 🚧 Not yet supported                                          | ✅ Supported | Not yet available via Keboola CLI.                                                             |
-| "Continue on Failure" toggle | 🔁 Replaced by Conditions | ✅ Simple UI toggle | Failure handling is expressed through conditions, offering more flexibility. (e.g., if status == 'error' then...)                  |
-
-## Migration
-
-We're planning an automatic migration from Legacy Flows to Flows to ensure a smooth transition without requiring manual intervention from users. This migration will preserve the logic, scheduling, and component configurations of existing flows while upgrading them to support conditional branching, retries, and other advanced features. In most cases, the migrated flows will look and behave the same - but with added flexibility under the hood.
 

--- a/flows/templates/templates.md
+++ b/flows/templates/templates.md
@@ -8,6 +8,11 @@ redirect_from:
 * TOC
 {:toc}
 
+<div class="alert alert-warning" role="alert">
+    <i class="fas fa-exclamation-circle"></i>
+    <strong>Important:</strong> Data templates create <a href="/flows/flows-legacy/">legacy flows</a>, which are no longer the recommended way to build data pipelines. For building new workflows, we recommend using the <a href="/kai/">Kai AI assistant</a>, which can help you set up flows and component configurations interactively.
+</div>
+
 Data templates are pre-defined sets of [component configurations](/components/). The individual configurations are connected 
 by a [flow](/flows/) and [metadata](/storage/tables/#metadata). Together they form a functional reusable block
 that solves a specific problem. 


### PR DESCRIPTION
Jira issue(s): N/A

Builds on top of #922 (swap Flows / Conditional Flows) → #921 (remove Orchestrator).

Changes:

- Added deprecation banner to the Templates page noting they create legacy flows and are no longer the recommended approach
- Banner recommends the [Kai AI assistant](/kai/) as the alternative for building new workflows and configurations
- Moved Templates under **Flows (Legacy)** in the navigation hierarchy, since templates create legacy flows

---

## Release Notes
**Justification, description**

Templates create legacy flows which are being deprecated. The banner directs users to the Kai AI assistant as the recommended alternative.

**Plans for Customer Communication**

N/A

**Impact Analysis**

Documentation-only change. Templates navigation moved under Flows (Legacy).

**Deployment Plan**

N/A

**Rollback Plan**

N/A

**Post-Release Support Plan**

N/A

Link to Devin session: https://app.devin.ai/sessions/4bfbdd40d9fd42bba16205b3fb0937f0
Requested by: @natocTo