### PR TITLE
docs: mark Processed Tags as deprecated [AJDA-2783]

### DIFF
--- a/transformations/mappings/index.md
+++ b/transformations/mappings/index.md
@@ -234,9 +234,10 @@ will be used to select files.
 - **Query** --- if selecting files by tags is not precise enough, you can use 
 an [elastic query](https://www.elastic.co/guide/en/elasticsearch/reference/5.0/query-dsl-query-string-query.html#query-string-syntax)
 to refine the search. If you combine *query* with *tags*, both conditions must be met.
-- **Processed Tags** --- specify tags which will be assigned to the input files once the transformation is finished.
+- **Processed Tags** *(deprecated)* --- specify tags which will be assigned to the input files once the transformation is finished.
 This allows you to process Storage files in an incremental fashion. You can combine this setting with the *query* 
 option to omit already processed files in recurring transformations.
+This feature is deprecated and will be removed in a future update. The option is only visible for configurations that already use processed tags.
 
 ## Output Mapping
 An output mapping takes results (tables and files) from your transformation and stores them back in Storage. 


### PR DESCRIPTION
Jira issue(s): [AJDA-2783](https://linear.app/keboola/issue/AJDA-2783/zakazat-zalozeni-processed-tags-v-ui)

Changes:

- Mark Processed Tags in file input mapping documentation as deprecated
- Add note that the feature will be removed in a future update and is only visible for existing configurations

---

Related UI PR: https://github.com/keboola/ui/pull/5792

## Release Notes
**Justification, description**

Processed Tags feature is deprecated per incident decision. Documentation updated to reflect this.

**Plans for Customer Communication**

N/A

**Impact Analysis**

Documentation-only change in `transformations/mappings/index.md`.

**Deployment Plan**

N/A

**Rollback Plan**

N/A

**Post-Release Support Plan**

N/A

Link to Devin session: https://app.devin.ai/sessions/dc4a76045af442449110085ee2726533
Requested by: @natocTo