### PR TITLE
docs: warn that Python transformations store secrets in plaintext

### DIFF
--- a/components/applications/custom-python/index.md
+++ b/components/applications/custom-python/index.md
@@ -73,6 +73,8 @@ a target table name, or debug flags. Enter them as a JSON object.
 Any key starting with `#` (e.g., `#api_key`) will be **encrypted** when you save the configuration.
 The decrypted value is available to your code at runtime via `CommonInterface`.
 
+***Note:** Unlike [Python Transformations](/transformations/python-plain/), which store all code and parameters as plaintext, Custom Python encrypts any parameter whose key begins with `#`. Use Custom Python (or another component supporting `#`-encrypted parameters) to hold credentials — never a transformation.*
+
 ## Git Configuration
 
 When using **Get from Git repository** as your code source, fill in the repository settings:

--- a/transformations/python-plain/index.md
+++ b/transformations/python-plain/index.md
@@ -12,6 +12,8 @@ redirect_from:
 other operations are too difficult. Common data operations like joining, sorting, or grouping are still easier and 
 faster to do in [SQL Transformations](/transformations/#backends).
 
+***Warning:** Python transformations have **no facility for encrypting secrets**. Any credential you place in transformation code — API keys, passwords, tokens, connection strings — is stored as **plaintext** in the configuration. It is not encrypted at rest, it is readable by anyone with access to the project's configuration, and it is included when the configuration is processed by features such as the AI **Generate description**. **Do not put credentials in transformation code.** Instead, store them in the [Custom Python](/components/applications/custom-python/) application, where any parameter whose key starts with `#` is [encrypted](https://developers.keboola.com/overview/encryption/) and made available to your code as an environment variable at runtime.*
+
 ## Environment
 The Python script is running in an isolated [environment](https://developers.keboola.com/extend/#component).
 The Python version is updated regularly, few weeks after the official release. The update is always announced on the


### PR DESCRIPTION
## Why

Python transformations have **no facility for encrypting secrets**. Any credential placed in transformation code is stored as **plaintext** configuration, readable by anyone with access to the project's configuration and surfaced to features such as the AI *Generate description*. Today the docs don't state this clearly — the only mentions are the Custom Python "When to Use" table and a one-line aside in the Components → Configuration Description note.

## What

- **Python Transformation page** (`transformations/python-plain/index.md`): explicit `***Warning***` near the top — no secret encryption exists; never put credentials in transformation code; use Custom Python `#`-encrypted parameters instead (links to the [encryption overview](https://developers.keboola.com/overview/encryption/)).
- **Custom Python page** (`components/applications/custom-python/index.md`): reinforcing `***Note***` under **User Parameters** cross-linking back, contrasting plaintext transformations vs `#`-encrypted Custom Python params.

Copy is grounded only in publicly verifiable behavior. Matches the repo's `***Note:**` callout convention.
