### PR TITLE
docs: add AGENTS.md + CLAUDE.md; refresh README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,7 @@ dist
 .env.production
 
 # Claude / local dev tools — screenshots saved during dev sessions
-CLAUDE.md
-claude.md
+# (CLAUDE.md and AGENTS.md are committed — agent/contributor guides.)
 scripts/screenshot.mjs
 screenshot-*.png
 audit-*.png

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,125 @@
+# AGENTS.md — working in this repo
+
+Guide for AI coding agents (and humans) contributing to the Keboola documentation
+site. Read this before making changes.
+
+## What this is
+
+The official Keboola product documentation, served at **help.keboola.com**. Built
+with **Astro + Starlight**. Content is Markdown; the site builds to static HTML
+with full-text search (Pagefind), redirects, and a generated sidebar.
+
+## Quick start
+
+```bash
+npm install
+npm run dev        # dev server at http://localhost:4321 (hot reload)
+npm run build      # production build → dist/
+npm run gen:sidebar  # regenerate src/sidebar.mjs from _data/navigation.yml
+```
+
+- Node.js 22+.
+- Search (Pagefind) only works in a production build/preview, **not** in `npm run dev`.
+
+## ⚠️ Migration state — read this first
+
+The repo is mid-migration from **Jekyll → Astro** and currently **duplicates**:
+
+- **Jekyll source** lives in root content dirs (`transformations/`, `storage/`,
+  `components/`, …) plus `_config.yml`, `_layouts`, `_includes`, `_sass`.
+- **Astro content** in `src/content/docs/` is **generated from the Jekyll source**
+  by `scripts/migrate.mjs`.
+
+**Consequence:** until the switchover, **do not hand-edit `src/content/docs/`** —
+it is regenerated and your edits will be lost. Edit the **Jekyll source** in the
+root content dirs, then run `node scripts/migrate.mjs`.
+
+The final cutover is scripted in **`scripts/switchover.mjs`** (dry-run by default):
+it finalizes Astro, removes the Jekyll source, and makes `src/content/docs/` the
+single source of truth. **After the switchover**, edit `src/content/docs/`
+directly and `migrate.mjs` becomes obsolete.
+
+## Repo structure
+
+```
+src/
+  content/docs/   # GENERATED docs pages (do not hand-edit pre-switchover)
+  components/     # Starlight component overrides (PageTitle, Head, AskKaiDrawer, …)
+  styles/custom.css  # ALL UI/CSS customization lives here
+  integrations/   # custom Astro integrations (redirect-from, beacon-transforms)
+  sidebar.mjs     # GENERATED sidebar (from _data/navigation.yml)
+public/           # static assets served as-is (images, favicon, llms)
+api/chat.ts       # "Ask Kai" backend (Vercel function → Keboola AI Service)
+scripts/
+  migrate.mjs     # Jekyll → Astro content migration (source of truth pre-switchover)
+  convert-nav.mjs # builds src/sidebar.mjs from _data/navigation.yml
+  switchover.mjs  # final Jekyll→Astro cutover (dry-run by default)
+  audit-phase2.mjs# read-only migration-fidelity audit (links/images/headings/…)
+astro.config.mjs  # Astro + Starlight config
+_data/navigation.yml  # sidebar source (consumed by convert-nav.mjs)
+```
+
+## Core rules
+
+- **CSS / UI changes → only `src/styles/custom.css`.** Don't scatter `<style>`
+  blocks; don't restyle in components.
+- **Component behavior/markup → the relevant `src/components/*.astro`.**
+- **Content (pre-switchover) → Jekyll source + `migrate.mjs`**, never
+  `src/content/docs/` directly (see migration state above).
+- **Sidebar → `_data/navigation.yml`**, then `npm run gen:sidebar`. Don't
+  hand-edit `src/sidebar.mjs`.
+- **After merging `main`** into the work branch, re-run:
+  `node scripts/migrate.mjs && node scripts/convert-nav.mjs && npm run build`.
+- **Durable fixes go in the script**, not the generated output — anything baked
+  into `migrate.mjs` survives every rerun (see `AUDIT_LOG.md` for the pattern).
+- **Product facts vs content choices:** when unsure whether something is accurate
+  product behavior or a wording choice, ask a maintainer — don't guess.
+
+## Authoring content
+
+Frontmatter needs at least `title` and `slug`:
+
+```yaml
+---
+title: My Page Title
+slug: 'section/my-page'
+description: One-line summary (feeds search/RAG, meta, and the page lede).
+---
+```
+
+Admonitions:
+
+```markdown
+:::tip
+Helpful info.
+:::
+:::caution[Public Beta]
+Beta notice.
+:::
+```
+
+Images: place alongside the Markdown and reference with an absolute path
+(`![Alt](/section/page/image.png)`). Click-to-zoom is automatic.
+
+## Verify before pushing
+
+- `npm run build` is clean (no fatal errors).
+- For migration/link/image/table changes, run `node scripts/audit-phase2.mjs`
+  after building.
+- For CSS that must survive client-side navigation, verify in a **production
+  build** (`astro build && astro preview`) — dev injects `<style>` tags that
+  don't survive Astro view-transition swaps.
+
+## Workflow & deployment
+
+- Docs-as-code: changes go through PRs; a maintainer reviews and merges.
+- Production deploys via GitHub Actions (`.github/workflows/main.yml`) on push to
+  `main` (build → `aws s3 sync` to `help.keboola.com`).
+- The "Ask Kai" widget (`api/chat.ts`) is a Vercel function; it needs
+  `AI_SERVICE_URL` + `KBC_STORAGE_API_TOKEN` env vars.
+
+## Logs / references
+
+- `AUDIT_LOG.md` — migration-fidelity findings and their durable fixes.
+- `UI_FIXES_LOG.md` — UI/UX change log.
+- `DEV_DOCS_INTEGRATION.md` — proposal for unifying the developer docs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,25 @@
+# CLAUDE.md
+
+Guidance for Claude Code (and other agents) working in this repo.
+
+The full repo guide — stack, structure, commands, conventions, and the critical
+migration rules — lives in **AGENTS.md**. Read it first:
+
+@AGENTS.md
+
+## Claude-specific notes
+
+- **Dev server:** `npm run dev` → http://localhost:4321. Keep exactly **one**
+  dev server running; kill stale ones (`pkill -f "astro dev"`) before starting.
+- **Pre-switchover, content is generated.** Do not hand-edit `src/content/docs/`
+  — edit the Jekyll source in the root content dirs and run
+  `node scripts/migrate.mjs`. (See AGENTS.md → "Migration state".)
+- **CSS/UI changes go only in `src/styles/custom.css`.**
+- **Verify view-transition-sensitive CSS in a production build**
+  (`astro build && astro preview`), not `npm run dev` — Vite injects `<style>`
+  tags that don't survive Astro view-transition swaps.
+- **Screenshots:** save throwaways to `/tmp`, not the repo. `scripts/screenshot.mjs`
+  is a local-only helper (gitignored).
+- **Log changes:** UI changes → `UI_FIXES_LOG.md`; migration findings →
+  `AUDIT_LOG.md`.
+- **Ask a maintainer** for product facts vs. content choices instead of guessing.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,25 @@ The official documentation for Keboola, available at [help.keboola.com](https://
 
 [How to write documentation](https://keboola.atlassian.net/wiki/spaces/KB/pages/82935879/Public+documentation)
 
+> **Contributing with an AI agent?** See **[AGENTS.md](./AGENTS.md)** (and
+> **[CLAUDE.md](./CLAUDE.md)**) for the full repo guide and the critical rules.
+
+## Migration status (Jekyll → Astro)
+
+This repo is mid-migration from the old Jekyll site to Astro Starlight, and
+currently **keeps both side by side**:
+
+- The **Jekyll source** lives in the root content directories (`transformations/`,
+  `storage/`, `components/`, …) plus `_config.yml`, `_layouts`, `_includes`, `_sass`.
+- The **Astro content** in `src/content/docs/` is **generated from the Jekyll
+  source** by `scripts/migrate.mjs`.
+
+**Until the cutover, edit the Jekyll source — not `src/content/docs/`** (it is
+regenerated). The final switchover is scripted in `scripts/switchover.mjs`
+(dry-run by default): it finalizes Astro, removes the Jekyll source, and makes
+`src/content/docs/` the single source of truth. **After the switchover**, edit
+`src/content/docs/` directly.
+
 ## Prerequisites
 
 - [Node.js](https://nodejs.org/) 22 or later
@@ -43,7 +62,12 @@ The dev server supports hot reload — changes to content files are reflected im
 
 ## Writing Content
 
-Documentation pages are Markdown files in `src/content/docs/`. Each page needs frontmatter with at least a `title` and `slug`:
+Documentation pages are Markdown files. **Pre-switchover** they are authored in
+the Jekyll source (root content dirs) and regenerated into `src/content/docs/` by
+`scripts/migrate.mjs` — don't edit `src/content/docs/` directly yet (see
+[Migration status](#migration-status-jekyll--astro)). **Post-switchover** they are
+edited directly in `src/content/docs/`. Either way, each page needs frontmatter
+with at least a `title` and `slug`:
 
 ```yaml
 ---
@@ -87,7 +111,7 @@ npm run build
 ```
 
 Output goes to `dist/`. This generates static HTML with:
-- 264 documentation pages
+- 274 documentation pages
 - 162 redirect pages (from `redirect_from` frontmatter)
 - Full-text search index (via Pagefind)
 - Sitemap


### PR DESCRIPTION
Adds the agent/contributor guides Jordan asked for and brings the README up to date.

- **AGENTS.md** — canonical guide for AI agents (and humans): stack, quick-start
  commands, repo structure, core rules, content authoring, verify/deploy. Leads
  with the **critical migration rule**: pre-switchover the content is *generated*
  from the Jekyll source by `migrate.mjs`, so don't hand-edit `src/content/docs/`.
- **CLAUDE.md** — imports AGENTS.md (`@AGENTS.md`) so there's a single source of
  truth, plus Claude-specific operational notes. Now **tracked** (removed from
  `.gitignore`).
- **README.md** — adds a **Migration status (Jekyll → Astro)** section, fixes the
  "Writing Content" guidance for the current dual state, updates the page count
  (264 → 274), and links the agent guides.

Build is clean (274 pages). `scripts/screenshot.mjs` stays gitignored (local helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)