### PR TITLE
docs: AJDA-2897 repoint remaining Apiary links to api.keboola.com

### DIFF
--- a/components/index.md
+++ b/components/index.md
@@ -61,7 +61,7 @@ including Generic Extractor configurations.
 Many of these components also serve our internal purposes, and we decided to share them publicly to benefit our community.
 
 ### Private / Unlisted
-Some components are still unlisted for various reasons. Each stack's full list of components is accessible via the public [Storage API index call](https://keboola.docs.apiary.io/#reference/miscellaneous/api-index/component-list). 
+Some components are still unlisted for various reasons. Each stack's full list of components is accessible via the public [Storage API index call](https://api.keboola.com/?service=storage#get-/v2/storage). 
 Many of these are 3rd-party components. Users can add these components via their ID, but we cannot guarantee their functionality. 
 
 We may share our pre-release versions that exist in private Beta with our test user groups. In such a case, you will receive a component ID, which you can use to create the configuration. 
@@ -143,7 +143,7 @@ The bottom right panel shows a list of the configuration versions. Use the list 
 - compare any two successive versions.
 - roll back to an older version.
 
-All of the operations can be [accessed via an API](https://keboola.docs.apiary.io/#reference/component-configurations/create-config).
+All of the operations can be [accessed via an API](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/components/-componentId-/configs).
 The [developer guide](https://developers.keboola.com/integrate/storage/api/configurations/) explains how to work with configurations.
 
 **Important**: Component configurations do not count towards your project quota.

--- a/data-apps/storage-access/index.md
+++ b/data-apps/storage-access/index.md
@@ -119,7 +119,7 @@ If you manage Data App configurations through the Storage API (or via automation
 - **`destination`** — the full Storage table ID (`<stage>.<bucket>.<table>`) the app should be able to read and write. The table must exist before the app is deployed.
 - **`unload_strategy: "direct-grant"`** — required marker that tells the platform "grant the app's workspace direct SELECT/INSERT/UPDATE/DELETE/TRUNCATE on this table." Tables without this strategy in `storage.output.tables` are not exposed via Storage Access.
 
-To add or remove writable tables programmatically, update the Data App's configuration via the Storage API ([Component Configurations endpoint](https://keboola.docs.apiary.io/#reference/component-configurations)) and redeploy the app for the new permissions to take effect.
+To add or remove writable tables programmatically, update the Data App's configuration via the Storage API ([Component Configurations endpoint](https://api.keboola.com/?service=storage#tag--Component-Configurations)) and redeploy the app for the new permissions to take effect.
 
 ### Step 3: Deploy Your App
 

--- a/management/account/index.md
+++ b/management/account/index.md
@@ -160,7 +160,7 @@ When you decline the invitation, you'll lose the opportunity to enter the projec
 ![Screenshot -- Promo codes](/management/account/invitations.png)
 
 ## Tokens
-On the **Access Tokens** page, you can create tokens for the [Management API](https://keboolamanagementapi.docs.apiary.io/#).
+On the **Access Tokens** page, you can create tokens for the [Management API](https://api.keboola.com/?service=manage).
 Do not confuse them with [Storage API tokens](/management/project/tokens/), which are used for operations
 within a project. Management tokens are used for project-independent operations such as creating and moving projects,
 creating organizations and projects monitoring. This means that the Management API offers some features which are

--- a/storage/byobq/byobq.md
+++ b/storage/byobq/byobq.md
@@ -96,7 +96,7 @@ each section is tailored to ensure a smooth and efficient setup.
 
 ## 1. Register GCS File Storage in Keboola
 
-Once the GCS bucket is ready, register it in Keboola via the [Management API](https://keboolamanagementapi.docs.apiary.io/#reference/file-storages-gcs/file-storages-gcs-collection/create-file-storage). This requires a **Keboola Management API token** with super admin privileges. You can generate one in **Admin > Account > [Access Tokens](https://connection.keboola.com/admin/account/access-tokens)**.
+Once the GCS bucket is ready, register it in Keboola via the [Management API](https://api.keboola.com/?service=manage#post-/manage/file-storage-gcs). This requires a **Keboola Management API token** with super admin privileges. You can generate one in **Admin > Account > [Access Tokens](https://connection.keboola.com/admin/account/access-tokens)**.
 
 Send a `POST` request to `/manage/file-storage-gcs`:
 
@@ -164,4 +164,4 @@ A successful response returns HTTP `201` with an object containing the new backe
 
 ***Note:** Once both resources are registered, contact Keboola Support and provide the file storage ID and BigQuery backend ID. Support will set up your project with these backends.*
 
-For full API reference, see the [Keboola Management API documentation](https://keboolamanagementapi.docs.apiary.io/).
+For full API reference, see the [Keboola Management API documentation](https://api.keboola.com/?service=manage).

--- a/storage/byodb/external-buckets/index.md
+++ b/storage/byodb/external-buckets/index.md
@@ -156,7 +156,7 @@ If you wish to remove the schema, you must do so manually in your warehouse.
 
 * Table names can't be longer than **92 characters** and can contain only **alphanumeric** characters, **dashes**, and **underscores**. Tables that do not meet these requirements **will be ignored**.
 * Table names are not case-sensitive. You cannot create two tables with the same name that differ only in letter case.
-* [Creating snapshots](https://keboola.docs.apiary.io/#reference/table-snapshotting/create-or-list-snapshots/create-table-snapshot) from tables in external buckets is not supported.
+* [Creating snapshots](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/tables/-id-/snapshots) from tables in external buckets is not supported.
 * A read-only input mapping with an external dataset has a limitation. If you delete and recreate a registered table in the source schema, our [read-only input mapping](/workspace/#read-only-input-mapping) will lose access to this table. This occurs because we aim to limit clients from having excessive permissions, such as [OWNERSHIP](https://docs.snowflake.com/en/sql-reference/sql/grant-privilege#restrictions-and-limitations), on their external schemas. **However, manually refreshing the bucket addressess this issue.** <br> To permanently resolve this issue, you can manually grant the read-only input mapping role future access to your tables and views as illustrated below: <br>
 ```
 GRANT SELECT ON FUTURE TABLES IN SCHEMA "REPORTING"."sales_schema" TO ROLE KEBOOLA_8_RO;

--- a/storage/files/index.md
+++ b/storage/files/index.md
@@ -77,7 +77,7 @@ The maximum allowed size of an uploaded file is currently 2 GB (2,048,000,000 by
 This applies to both file and table uploads. 
 The actual table size may be bigger, because the table is uploaded as a compressed file. 
 If you need to upload a larger file, you need to use 
-[sliced upload](https://keboola.docs.apiary.io/#reference/files). 
+sliced upload. 
 In that case, the limit applies to the chunk size.
 
 As stated above, unless marked as permanent, each file will be automatically deleted 15 days after its creation. 

--- a/storage/index.md
+++ b/storage/index.md
@@ -14,7 +14,7 @@ It is implemented as a layer on top of database engines that we use as our backe
 By default all new [Pay As You Go projects](/management/payg-project/) use the BigQuery backend. If you are a contract customer, you can select which backend you want to use.
 
 As with all other Keboola components, everything that can be done through the UI can be also done programmatically
-via the [Storage API](https://keboola.docs.apiary.io/).
+via the [Storage API](https://api.keboola.com/?service=storage).
 See our [developers guide](https://developers.keboola.com/integrate/storage/) to learn more.
 Every Storage operation must be authorized via a [token](/management/project/tokens/).
 It is also recorded in [Events](/management/project/tokens/#token-events) and

--- a/transformations/dbt/cloud/cloud.md
+++ b/transformations/dbt/cloud/cloud.md
@@ -40,7 +40,7 @@ Search by tag (component type or configuration ID):
 
 ![](imgs/2776269036.png){: width="100%" }
 
-**Tip:**: Those files can be also easily [retrieved externally via the API](https://keboola.docs.apiary.io/#reference/files/list-files/list-files) or from an integrated Jupyter workspace for further analysis.
+**Tip:**: Those files can be also easily [retrieved externally via the API](https://api.keboola.com/?service=storage#get-/v2/storage/branch/-branchId-/files) or from an integrated Jupyter workspace for further analysis.
 
 *Note: Please keep in mind that the base URL of the API call depends on the stack you are using: US vs. Azure EU vs. EU central.*
 


### PR DESCRIPTION
@
Jira issue(s): [AJDA-2897](https://linear.app/keboola/issue/AJDA-2897/odstranit-zbyvajici-odkazy-na-apiary)

Apiary is retired. This repoints the remaining `*.docs.apiary.io` API documentation links in connection-docs to the new RapiDoc portal at `api.keboola.com` (`?service=storage` for Storage API, `?service=manage` for the Management API), matching the migration already done in developers-docs (#385, #389).

Changes:

- Storage API links → `https://api.keboola.com/?service=storage#<anchor>` (storage index, component list/config endpoints, files list, table snapshots, component configurations)
- Management API links → `https://api.keboola.com/?service=manage#<anchor>` (account tokens, BYOBQ file-storage-gcs registration)
- Removed the `sliced upload` link in `storage/files` (kept as plain text)
- Left the undocumented `table-export` and `create-table-definition` endpoints untouched — they have no portal equivalent, so any rewrite would be a dead link

---

Pure docs link-target changes; no content or behavior impact.
@