### PR TITLE
fix(AskKaiDrawer): persist a wrapper div, not the <dialog> — fixes view-transition crash

### DIFF
--- a/src/components/AskKaiDrawer.astro
+++ b/src/components/AskKaiDrawer.astro
@@ -13,7 +13,13 @@
  */
 ---
 
-<dialog id="ask-kai-drawer" aria-label="Ask Kai about the Keboola docs" transition:persist>
+<!-- Persist a wrapper <div>, NOT the <dialog> itself. transition:persist on a
+     <dialog> throws "InvalidStateError: Transition was aborted because of invalid
+     state" on every Astro view-transition navigation (a <dialog> can't be moved
+     across the transition). Persisting this wrapper keeps the drawer's DOM and
+     conversation history across navigations without breaking the transition. -->
+<div id="ask-kai-persist" transition:persist>
+<dialog id="ask-kai-drawer" aria-label="Ask Kai about the Keboola docs">
   <div class="ak-shell">
     <header class="ak-header">
       <div class="ak-title">
@@ -57,6 +63,7 @@
     </form>
   </div>
 </dialog>
+</div>
 
 <script>
   import { marked } from 'marked';


### PR DESCRIPTION
## Problem

Every **client-side (view-transition) navigation** on the live docs site throws:

```
InvalidStateError: Transition was aborted because of invalid state
```

The most visible symptom: after navigating between docs pages via the sidebar, opening **search** shows an empty modal that needs several clicks to work. Search/Pagefind are fine — they're downstream. The aborted transition leaves Starlight's (persisted) search dialog un-reconciled, so it opens blank until a retry.

## Root cause

`AskKaiDrawer.astro` set `transition:persist` **directly on a `<dialog>`**:

```astro
<dialog id="ask-kai-drawer" ... transition:persist>
```

`transition:persist` carries an element across each navigation by moving it into the new page's DOM. A `<dialog>` can't be moved that way (top-layer / dialog state), so the View Transitions API aborts the transition — on **every** navigation, regardless of whether the drawer was ever opened (verified: 2 client-side navigations → 2 errors, no search interaction). It was the only `transition:persist` in the codebase.

## Fix

Persist a **wrapper `<div>`**, not the `<dialog>`:

```astro
<div id="ask-kai-persist" transition:persist>
  <dialog id="ask-kai-drawer" ...>   <!-- no transition:persist -->
    ...
  </dialog>
</div>
```

The dialog (and the Kai conversation DOM) still persists as part of the wrapper's subtree, so the drawer's behavior and chat history survive navigation and the once-run script's element references stay valid — but the *persisted element* is now a plain `<div>`, so the transition no longer aborts.

## Verification

- `npm run build` clean — 254 pages, Pagefind index built.
- **Please confirm on the Vercel preview**: navigate between docs pages via the sidebar (client-side), then open search — it should populate on the first click, with no `InvalidStateError` in the console. Also confirm the Ask Kai drawer still opens and retains its conversation across navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
