### PR TITLE
docs: rewrite Google Analytics page for GA4, remove UA references

### DIFF
--- a/src/content/docs/components/extractors/marketing-sales/google-analytics/index.md
+++ b/src/content/docs/components/extractors/marketing-sales/google-analytics/index.md
@@ -25,16 +25,12 @@ The Google Analytics connector uses the [Google Analytics Data API (v1)](https:/
 
 ## How Data Loading Works
 
-There are two distinct "incremental" concepts in this connector. Understanding the difference helps avoid confusion:
+There are two distinct "incremental" concepts in this connector:
 
 | Concept | What it means | How it's controlled |
 |---------|--------------|-------------------|
 | **Incremental storage writes** | Data is always **upserted** into Keboola Storage tables using primary keys. Existing rows with matching keys are updated; new rows are appended. Old data is never deleted or replaced. | **Always on** — this is hardcoded in the connector and cannot be changed. |
 | **Incremental date fetching** | The connector fetches only data **since the last successful run** instead of re-downloading a fixed date range each time. | **Optional** — controlled by the "Incremental load" checkbox in the date range settings. |
-
-In summary:
-- Your Storage tables always grow incrementally (upsert) regardless of configuration.
-- The *date range* determines how much data is fetched from the Google API on each run — either a fixed window (e.g., "last 7 days") or from the last run date onward.
 
 ## Configuration
 [Create a new configuration](/components/#creating-component-configuration) of the **Google Analytics** connector.

--- a/src/content/docs/components/extractors/marketing-sales/google-analytics/index.md
+++ b/src/content/docs/components/extractors/marketing-sales/google-analytics/index.md
@@ -1,137 +1,113 @@
 ---
-title: Google Analytics (UA, GA4)
+title: Google Analytics 4 (GA4)
 slug: 'components/extractors/marketing-sales/google-analytics'
 redirect_from:
     - /extractors/marketing-sales/google-analytics/
 
 ---
 
+This data source connector allows you to integrate your Google Analytics 4 data into the Keboola environment.
+To do that, you will need a [Google Analytics account](https://analytics.google.com/analytics/web/) with at least one GA4 property.
 
-
-This data source connector allows you to integrate your Google Analytics data into the Keboola environment.
-To do that, you will need a [Google Analytics account](https://analytics.google.com/analytics/web/).
-
-**Note:** This component supports both Google Analytics 4 (GA4) and old Universal Analytics (UA).
+:::caution[Universal Analytics Sunset]
+Google discontinued Universal Analytics on July 1, 2024. The UA Reporting API and Multi-Channel Funnels API are no longer available.
+This connector now works exclusively with **Google Analytics 4 (GA4)** via the [Data API](https://developers.google.com/analytics/devguides/reporting/data/v1).
+:::
 
 ## Features
-The Google Analytics connector works with the newest version of the [Google Analytics 4 (GA4)](https://developers.google.com/analytics/devguides/reporting/data/v1) (Google Analytics Data API)
-and [Universal Analytics](https://developers.google.com/analytics/devguides/reporting/core/v4/) (Google Analytics Reporting API - V4).
+The Google Analytics connector uses the [Google Analytics Data API (v1)](https://developers.google.com/analytics/devguides/reporting/data/v1), which provides:
 
-These APIs provides the following key features:
+ - **Flexible metrics and dimensions** --- Query any combination of GA4 metrics and dimensions available in your property.
 
- - **Metric expressions** --- The API allows you to request not only built-in metrics but also combinations of metrics expressed in mathematical operations. For example, you can use the expression `ga:goal1completions/ga:sessions` to request the goal completions per number of sessions.
+ - **Multiple date ranges** --- Get data in up to four date ranges in a single request, useful for period-over-period comparisons.
 
- - **Multiple date ranges** --- The API allows you to get data in two date ranges in a single request.
+ - **Dimension and metric filters** --- Filter the report data server-side before it reaches Keboola.
 
- - **Multiple segments** --- The API enables you to get multiple segments in a single request.
- 
-**Important:** Data is always imported incrementally.
+## How Data Loading Works
+
+There are two distinct "incremental" concepts in this connector. Understanding the difference helps avoid confusion:
+
+| Concept | What it means | How it's controlled |
+|---------|--------------|-------------------|
+| **Incremental storage writes** | Data is always **upserted** into Keboola Storage tables using primary keys. Existing rows with matching keys are updated; new rows are appended. Old data is never deleted or replaced. | **Always on** — this is hardcoded in the connector and cannot be changed. |
+| **Incremental date fetching** | The connector fetches only data **since the last successful run** instead of re-downloading a fixed date range each time. | **Optional** — controlled by the "Incremental load" checkbox in the date range settings. |
+
+In summary:
+- Your Storage tables always grow incrementally (upsert) regardless of configuration.
+- The *date range* determines how much data is fetched from the Google API on each run — either a fixed window (e.g., "last 7 days") or from the last run date onward.
 
 ## Configuration
 [Create a new configuration](/components/#creating-component-configuration) of the **Google Analytics** connector.
-Then click **Authorize Account** to [authorize the configuration](/components/#authorization). 
-Select the desired Google Analytics account and profiles (Reporting API view) or GA4 properties (Data API view) from which you would like to extract data.
+Then click **Authorize Account** to [authorize the configuration](/components/#authorization).
+Select the desired Google Analytics account and GA4 properties from which you would like to extract data.
 
 ![Screenshot - Intro Page](/components/extractors/marketing-sales/google-analytics/google-analytics-1.png)
 
-![Screenshot - Select Profiles](/components/extractors/marketing-sales/google-analytics/google-analytics-2.png)
+![Screenshot - Select Properties](/components/extractors/marketing-sales/google-analytics/google-analytics-2.png)
 
-## Create New Query
-Each query consists of metrics, dimensions and a date range. Optionally, it can be filtered by a filter expression or a segment.
-Let's create a simple query with some basic metrics such as Sessions, Users and Pageviews.
+## Create a New Query
+Each query consists of metrics, dimensions, and a date range. Optionally, it can be filtered.
 
-![Screenshot - Create New Query](/components/extractors/marketing-sales/google-analytics/google-analytics-3.png)
+1. Name your output table in Storage, for example, `sessions_overview`.
 
- 1. From API selector choose `Reporting API`.
+2. From the metrics selector, choose the desired metrics (e.g., `sessions`, `totalUsers`, `screenPageViews`).
 
- 2. Name your table in the storage, for example, `tutorialTable`.
+3. From the dimensions selector, choose dimensions (e.g., `date`, `sessionSource`).
 
- 3. From the metrics selector, choose the following metrics: `ga:sessions`, `ga:users`, `ga:pageviews`.
+4. Configure the date range (default is last 4 days).
 
- 4. From the dimensions selector, choose the `ga:date` dimension.
+5. Click **Test query** to preview results.
 
- 5. Leave the date range on default (last 4 days).
+6. Save your query when you are satisfied with the results.
 
- 6. See the query results by hitting the `Test query` button.
-
- 7. Now you see sessions, users, and pageviews of the last five days sliced by date.
-
- 8. When you are happy with the results, save your query.
-
- 9. To store the results to Storage, click the "play" icon on the query list page.
-
-![Screenshot - Query Details](/components/extractors/marketing-sales/google-analytics/google-analytics-4.png)
+7. To run the extraction, click the "play" icon on the query list page.
 
 ## Date Ranges
 A date range specifies a time window from which the data will be extracted.
 You can use any expression compatible with the [PHP strtotime() function](https://www.php.net/manual/en/datetime.formats.php).
 
-**Multiple date ranges** are useful, for example, when you want to compare metric performance to the previous date range.
-Let's say you want to see Sessions by month, compared to the same month last year.
-Of course, you can download all the data from last year, but with this approach, you can download just the data you need.
+**Multiple date ranges** are useful when you want to compare metric performance across periods.
+For example, you can compare sessions this month to the same period last year without downloading all historical data.
 
-**Incremental load**, when you want download data from the previous job.
+### Incremental Date Fetching
+When you want to download only data that appeared since the previous extraction run, enable **Incremental load** in the date range settings. This sets the start date to the date of the last successful run.
 
-Notice: **Multiple date ranges** and **Incremental load** cannot be uses together.
+:::note
+**Multiple date ranges** and **Incremental load** cannot be used together. When incremental load is active, only one date range is allowed.
+:::
 
 ## Anti-Sampling
-The Google Analytics API does not always return precise data. Under certain circumstances, the data 
+The Google Analytics API does not always return precise data. Under certain circumstances, the data
 returned is [sampled](https://support.google.com/analytics/answer/2637192?hl=en).
-To work around this problem and get more precise results, choose either the DailyWalk or Adaptive 
-anti-sampling algorithm. Both divide the wanted date range into smaller chunks. You can configure
-anti-sampling in the query detail.
+To work around this problem and get more precise results, choose the **DailyWalk**
+anti-sampling algorithm. It divides the date range into daily chunks, making separate requests for each day.
+
+You can configure anti-sampling in the query detail.
 
 ![Screenshot - Anti Sampling](/components/extractors/marketing-sales/google-analytics/google-analytics-5.png)
 
-**DailyWalk**, as the name suggests, divides the date range by days. It means that the data source connector needs to 
-make as many requests as there are days in the date range. Even though this algorithm might be more 
-precise in some cases, you usually get the same results faster with the Adaptive algorithm.
+## Dimension and Metric Filters
+Filters allow you to limit the data included in a report. For example, you can filter by a specific
+country, traffic source, or device category.
 
-The **Adaptive** algorithm uses a more sophisticated approach, splitting the original date range into 
-few smaller date sections. To learn more about it, read this [in-depth explanation](http://code.markedmondson.me/anti-sampling-google-analytics-api/). 
-
-## Filters
-Filters allow you to limit and modify the data that is included in a view. For example, you can use 
-filters to exclude traffic from particular IP addresses, focus on a specific subdomain or directory, or 
-convert dynamic page URLs into readable text strings.
-If interested, read more about [how to use filters](https://support.google.com/analytics/answer/1033162).
-
-Learn how to [construct a filter expression](https://developers.google.com/analytics/devguides/reporting/core/v3/reference#filters).
-
-## Segments
-A segment is a subset of your Analytics data. For example, of your entire set of users,
-one segment might be users from a particular country or city.
-Another segment might be users who purchase a particular line of products or who visit a specific part of your site.
-[Read more](https://support.google.com/analytics/answer/3123951?hl=en).
-
-**Important:** When you want to use segments, use the `ga:segments` dimension.
-You will have to type it in, however, because it is not in the option list of dimensions.
-
-## Custom Dimensions and Metrics
-It is possible to use custom dimensions and metrics.
-Although they are not listed in the selector options, you can type them in manually.
-Insert the dimension or metric ID in the format of `ga:metricXX` or `ga:dimensionXX` where XX is a number, for example `ga:metric1`.
-
-You can find the IDs on the Google Analytics page:
-
-![Screenshot - Custom metric ID](/components/extractors/marketing-sales/google-analytics/google_console_metrics.png)
+Learn how to construct filters in the [GA4 Data API documentation](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/FilterExpression).
 
 ## Custom OAuth Credentials
 To avoid hitting quota limits, you can use your own OAuth Client ID and Secret:
 
 1. Visit the [Google API Console](https://console.developers.google.com/).
 2. Select an existing project or create a new one.
- 
+
 ![Screenshot - Google API Console - Project](/components/extractors/marketing-sales/google-analytics/google_console_project.png)
 
-3. Enable the [Google Analytics Data API](https://console.cloud.google.com/apis/library/analyticsdata.googleapis.com) and [Google Analytics Admin API](https://console.cloud.google.com/apis/library/analyticsadmin.googleapis.com) if you plan to use [Google Analytics Data API](https://developers.google.com/analytics/devguides/reporting/data/v1) or enable the [Google Analytics Reporting API](https://console.developers.google.com/apis/library/analyticsreporting.googleapis.com) if you plan to use the [Reporting API](https://developers.google.com/analytics/devguides/reporting/core/v4) or [Multi-Channel Funnels API](https://developers.google.com/analytics/devguides/reporting/mcf/v3). You also need to enable [Google Analytcics API](https://console.developers.google.com/apis/library/analytics.googleapis.com).
- 
+3. Enable the [Google Analytics Data API](https://console.cloud.google.com/apis/library/analyticsdata.googleapis.com) and [Google Analytics Admin API](https://console.cloud.google.com/apis/library/analyticsadmin.googleapis.com).
+
 ![Screenshot - Google API Console - Enable API](/components/extractors/marketing-sales/google-analytics/google_console_enable.png)
-    
+
 4. Select the **Credentials** section from the menu on the left, click the **Create credentials** button and select **OAuth client ID**.
-  
+
 ![Screenshot - Google API Console - Create Credentials](/components/extractors/marketing-sales/google-analytics/google_console_credentials.png)
-    
+
 5. Choose **Web Application**. Into **Authorized redirect URIs** insert:
     - `https://oauth.keboola.com/authorize/keboola.ex-google-analytics-v4/callback`
     - or `https://oauth.eu-central-1.keboola.com/authorize/keboola.ex-google-analytics-v4/callback`
@@ -139,9 +115,9 @@ To avoid hitting quota limits, you can use your own OAuth Client ID and Secret:
 
 6. Click **Create** and a popup window will display your new Client ID and Client Secret credentials.
 7. Find your credentials in the list of available credentials. You should see something like this:
- 
+
 ![Screenshot - Google API Console - Credentials Detail](/components/extractors/marketing-sales/google-analytics/google_console_detail.png)
-  
+
 8. You can now use these credentials in the **Custom Authorization** tab when authorizing the Google Analytics data source connector.
- 
+
 ![Screenshot - KBC - Custom Authorization](/components/extractors/marketing-sales/google-analytics/google-analytics-6.png)


### PR DESCRIPTION
Jira issue(s): [UT-4223](https://linear.app/keboola/issue/UT-4223/support-16445-invisible-button)

Changes:

- Removed all Universal Analytics (UA) and Multi-Channel Funnels (MCF) API references — these were sunset by Google on July 1, 2024
- Focused content exclusively on GA4 Data API
- Added new "How Data Loading Works" section with a table clearly explaining the two incremental concepts:
  - **Incremental storage writes** — always on, hardcoded upsert based on primary keys
  - **Incremental date fetching** — optional, controlled by the "Incremental load" checkbox
- Removed UA-only sections: Segments, Custom Dimensions with `ga:` prefix, UA-specific filters
- Updated Custom OAuth section to reference GA4 Data API and Admin API
- Updated tutorial examples to use GA4 metric/dimension names

---

This addresses confusion reported in SUPPORT-16445 where users see "Incremental load" unchecked but docs say data is always imported incrementally. Both statements are true but refer to different concepts — this rewrite makes that distinction explicit.

Link to Devin session: https://app.devin.ai/sessions/f5b5bf58f3fc427f9dd2dbc6dedeade3
Requested by: @natocTo