### PR TITLE
fix(Ask Kai): correct AI Service response mapping + stack sources under the answer

### DIFF
--- a/api/chat.ts
+++ b/api/chat.ts
@@ -91,17 +91,21 @@ async function askDocsQuestion(
     throw new Error(`AI Service /docs/question failed: HTTP ${res.status}`);
   }
 
-  // DocsResponse: { response: string, metadata: { sources: string[] } }
+  // DocsResponse: { text: string, sourceUrls: string[] }.
+  // (An earlier build expected { response, metadata.sources }; the live AI
+  //  Service returns { text, sourceUrls } — read those, but tolerate the old
+  //  shape too so a future revert on either side doesn't silently blank Kai.)
   const data = (await res.json()) as {
+    text?: string;
+    sourceUrls?: string[];
     response?: string;
     metadata?: { sources?: string[] };
   };
 
+  const sources = data.sourceUrls ?? data.metadata?.sources;
   return {
-    text: data.response ?? '',
-    source_urls: Array.isArray(data.metadata?.sources)
-      ? (data.metadata!.sources as string[])
-      : [],
+    text: data.text ?? data.response ?? '',
+    source_urls: Array.isArray(sources) ? sources : [],
   };
 }
 


### PR DESCRIPTION
## Problem

"Ask Kai" returned **empty answers** in the docs — the drawer opens, shows "Searching docs… / Writing answer…", then displays nothing (and no sources).

## Root cause

Not the widget, the env, or the deploy — all of those are healthy (domain is on Vercel, `GET /api/chat` → `{"enabled":true}`, the function runs). The bug is a **response-shape mismatch** between `api/chat.ts` and the AI Service.

The proxy expected `{ response, metadata: { sources } }` and read `data.response` / `data.metadata.sources`. But the live AI Service (`POST ai…keboola.com/docs/question`) actually returns:

```json
{ "text": "…answer…", "sourceUrls": ["https://help.keboola.com/storage/buckets/", …] }
```

So `data.response` was always `undefined` → `?? ''` → empty answer, and `data.metadata?.sources` → no source chips. The backend was answering correctly the whole time (verified directly: HTTP 201, a full answer + 6 sources for "what is a bucket?"); the proxy was just reading keys that don't exist. This matches the recent "Kai → AI Service API, dropped the MCP" change introducing the proxy against an assumed shape that didn't match the endpoint.

## Fix

Read the real fields (`text`, `sourceUrls`), while still tolerating the old shape so a future change on either side fails safe rather than silently blanking Kai:

```ts
text: data.text ?? data.response ?? '',
source_urls: Array.isArray(data.sourceUrls ?? data.metadata?.sources) ? … : [],
```

## Verification

- Confirmed the live `/docs/question` response shape directly — it returns `{ text, sourceUrls }`.
- `tsc --noEmit` clean on `api/chat.ts`.
- **Please confirm on deploy**: ask Kai a question and verify it now streams the answer + source chips. (Preview will only exercise this if the `AI_SERVICE_URL` + `KBC_STORAGE_API_TOKEN` env vars are also set for the Preview environment, not just Production.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
