### PR TITLE
ui: rename Edit Page button to Suggest an Edit with tooltip

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -44,6 +44,7 @@ export default defineConfig({
         Head: './src/components/Head.astro',
         PageTitle: './src/components/PageTitle.astro',
         Footer: './src/components/Footer.astro',
+        EditLink: './src/components/EditLink.astro',
       },
       pagination: true,
       editLink: {

--- a/src/components/EditLink.astro
+++ b/src/components/EditLink.astro
@@ -1,20 +1,13 @@
 ---
-import type { Props } from '@astrojs/starlight/props';
+import Icon from '@astrojs/starlight/components/Icon.astro';
 
-const { editUrl } = Astro.props;
+const { editUrl } = Astro.locals.starlightRoute;
 const tooltip = 'Want to improve this page? Submit a pull request on GitHub. We review all suggestions within 48 hours.';
 ---
 {editUrl && (
   <div class="suggest-edit-wrapper" data-tooltip={tooltip}>
-    <a
-      href={editUrl.href}
-      rel="noopener noreferrer"
-      target="_blank"
-      class="sl-flex suggest-edit-link"
-    >
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="1em" height="1em" aria-hidden="true" fill="currentColor">
-        <path d="m14.06 9.02.92.92L5.92 19H5v-.92l9.06-9.06M17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83a.996.996 0 0 0 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75z"/>
-      </svg>
+    <a href={editUrl} class="sl-flex suggest-edit-link print:hidden">
+      <Icon name="pencil" size="1.2em" />
       Suggest an Edit
     </a>
   </div>

--- a/src/components/EditLink.astro
+++ b/src/components/EditLink.astro
@@ -1,13 +1,13 @@
 ---
-import Icon from '@astrojs/starlight/components/Icon.astro';
-
 const { editUrl } = Astro.locals.starlightRoute;
 const tooltip = 'Want to improve this page? Submit a pull request on GitHub. We review all suggestions within 48 hours.';
 ---
 {editUrl && (
   <div class="suggest-edit-wrapper" data-tooltip={tooltip}>
     <a href={editUrl} class="sl-flex suggest-edit-link print:hidden">
-      <Icon name="pencil" size="1.2em" />
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="1.2em" height="1.2em" aria-hidden="true" fill="currentColor">
+        <path d="m14.06 9.02.92.92L5.92 19H5v-.92l9.06-9.06M17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83a.996.996 0 0 0 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75z"/>
+      </svg>
       Suggest an Edit
     </a>
   </div>

--- a/src/components/EditLink.astro
+++ b/src/components/EditLink.astro
@@ -1,0 +1,21 @@
+---
+import type { Props } from '@astrojs/starlight/props';
+
+const { editUrl } = Astro.props;
+const tooltip = 'Want to improve this page? Submit a pull request on GitHub. We review all suggestions within 48 hours.';
+---
+{editUrl && (
+  <div class="suggest-edit-wrapper" data-tooltip={tooltip}>
+    <a
+      href={editUrl.href}
+      rel="noopener noreferrer"
+      target="_blank"
+      class="sl-flex suggest-edit-link"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="1em" height="1em" aria-hidden="true" fill="currentColor">
+        <path d="m14.06 9.02.92.92L5.92 19H5v-.92l9.06-9.06M17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83a.996.996 0 0 0 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75z"/>
+      </svg>
+      Suggest an Edit
+    </a>
+  </div>
+)}

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -1758,3 +1758,45 @@ nav.sidebar {
   #ask-kai-drawer .ak-shell { width: 100vw; }
   #ak-fab { bottom: 20px; right: 16px; }
 }
+
+/* ───────── Suggest an Edit button + tooltip ───────── */
+.suggest-edit-wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
+.suggest-edit-link {
+  align-items: center;
+  gap: 0.5em;
+  color: var(--sl-color-text-accent);
+  text-decoration: none;
+  font-size: var(--sl-text-sm);
+}
+
+.suggest-edit-link:hover {
+  color: var(--sl-color-white);
+}
+
+.suggest-edit-wrapper::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 0.5rem);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--sl-color-gray-1);
+  color: var(--sl-color-gray-7);
+  font-size: var(--sl-text-xs);
+  padding: 0.4rem 0.65rem;
+  border-radius: 0.3rem;
+  white-space: normal;
+  width: 220px;
+  text-align: center;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  z-index: 10;
+}
+
+.suggest-edit-wrapper:hover::after {
+  opacity: 1;
+}


### PR DESCRIPTION
## Summary
- Renames the "Edit Page" button at the bottom of every docs page to **"Suggest an Edit"**
- Adds a hover tooltip: *"Want to improve this page? Submit a pull request on GitHub. We review all suggestions within 48 hours."*

## Changes
- `src/components/EditLink.astro` — new Starlight component override with the updated label and tooltip markup
- `src/styles/custom.css` — tooltip styles appended (per repo convention — no `<style>` blocks in components)
- `astro.config.mjs` — registers `EditLink` in the Starlight component overrides map

## Test plan
- [ ] Run `npm run dev` and confirm the button reads "Suggest an Edit" on any docs page
- [ ] Hover over the button and confirm the tooltip appears with the correct text
- [ ] Confirm the link still points to the correct GitHub edit URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)