### PR TITLE
fix(search): re-init Pagefind on view-transition navigations

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -8,6 +8,8 @@
  */
 import Default from '@astrojs/starlight/components/Footer.astro';
 import AskKaiDrawer from './AskKaiDrawer.astro';
+import SearchPersistFix from './SearchPersistFix.astro';
 ---
 <Default><slot /></Default>
 <AskKaiDrawer />
+<SearchPersistFix />

--- a/src/components/SearchPersistFix.astro
+++ b/src/components/SearchPersistFix.astro
@@ -1,0 +1,75 @@
+---
+/**
+ * SearchPersistFix.astro
+ *
+ * Starlight's <Search> component (node_modules/@astrojs/starlight/components/
+ * Search.astro) initializes the Pagefind search UI inside a `DOMContentLoaded`
+ * handler. That event fires once per full page load and NEVER on Astro
+ * view-transition (ClientRouter) navigations — which this site enables in
+ * Head.astro for SPA-style navigation. So after any client-side navigation a
+ * fresh, EMPTY `#starlight__search` container is swapped in and the search box
+ * opens blank ("search doesn't work after clicking around").
+ *
+ * Fix: re-initialize Pagefind on every `astro:page-load` AFTER the first one.
+ * The initial load is already handled by Starlight's own DOMContentLoaded init,
+ * so we skip it (avoids a double-init race). PagefindUI options mirror
+ * Starlight's Search.astro exactly so behavior is identical.
+ */
+---
+
+<script>
+  import { pagefindUserConfig } from 'virtual:starlight/pagefind-config';
+
+  // Pagefind only runs in production builds (Starlight shows a dev-mode notice
+  // instead of the search UI), so there is nothing to re-initialize in dev.
+  if (!import.meta.env.DEV) {
+    const initSearch = async () => {
+      const container = document.querySelector('#starlight__search');
+      // Not a docs page, or Starlight already populated it → nothing to do.
+      if (!container || container.childElementCount > 0) return;
+
+      const siteSearch = document.querySelector('site-search') as HTMLElement | null;
+      let translations = {};
+      try {
+        translations = JSON.parse(siteSearch?.dataset.translations || '{}');
+      } catch {}
+      const shouldStrip = siteSearch?.dataset.stripTrailingSlash !== undefined;
+      const stripTrailingSlash = (path: string) => path.replace(/(.)\/(#.*)?$/, '$1$2');
+      const formatURL = shouldStrip ? stripTrailingSlash : (path: string) => path;
+
+      // @ts-expect-error — Missing types for @pagefind/default-ui package.
+      const { PagefindUI } = await import('@pagefind/default-ui');
+      // Re-check after the async import in case a rapid second navigation
+      // already re-initialized this container.
+      if (container.childElementCount > 0) return;
+      new PagefindUI({
+        ...pagefindUserConfig,
+        element: '#starlight__search',
+        baseUrl: import.meta.env.BASE_URL,
+        bundlePath: import.meta.env.BASE_URL.replace(/\/$/, '') + '/pagefind/',
+        showImages: false,
+        translations,
+        showSubResults: true,
+        processResult: (result: { url: string; sub_results: Array<{ url: string }> }) => {
+          result.url = formatURL(result.url);
+          result.sub_results = result.sub_results.map((sub_result) => {
+            sub_result.url = formatURL(sub_result.url);
+            return sub_result;
+          });
+        },
+      });
+    };
+
+    // The first astro:page-load corresponds to the initial full load, which
+    // Starlight's own DOMContentLoaded handler already covers — skip it. Every
+    // subsequent fire is a view-transition navigation that Starlight misses.
+    let initialLoad = true;
+    document.addEventListener('astro:page-load', () => {
+      if (initialLoad) {
+        initialLoad = false;
+        return;
+      }
+      initSearch();
+    });
+  }
+</script>


### PR DESCRIPTION
## Problem

On the live docs, search is unreliable: after clicking around, opening search shows an **empty modal** ("the search box doesn't show up / opens blank"). It only works right after a full page load / hard refresh.

## Root cause

Starlight's `Search.astro` initializes the Pagefind search UI inside a **`DOMContentLoaded`** handler. That event fires once per full page load and **never on Astro view-transition (`ClientRouter`) navigations** — which this site enables in `Head.astro` for SPA-style navigation. So after any internal (soft) navigation, a fresh, **empty** `#starlight__search` container is swapped in and Pagefind is never re-injected.

Verified by direct DOM inspection on a production build:

| State | Pagefind UI in `#starlight__search` | innerHTML |
|---|---|---|
| Fresh full load | present | 507 |
| After soft (view-transition) nav | absent | 0 |

This is **independent of the Ask Kai drawer and `transition:persist`** — which is why the earlier wrapper-`<div>` attempt (`fix/askkai-drawer-view-transition`) did not fix it.

## Fix

Add `SearchPersistFix.astro` (rendered site-wide via `Footer.astro`) that re-runs the Pagefind init on every `astro:page-load` **after the first**, mirroring Starlight's own `PagefindUI` options. The initial load is still handled by Starlight's `DOMContentLoaded` init, so the first event is skipped to avoid a double-init. ClientRouter and the Ask Kai drawer are untouched.

## Verification (local production build)

- Fresh load -> search works (unchanged)
- 1st soft nav -> search **now works** (was empty)
- 2nd consecutive soft nav (deep link, different section) -> still works
- Functional query after nav: **"67 results for bucket"**, real results rendered

## Out of scope (separate follow-up)

There is also an `InvalidStateError: Transition was aborted because of invalid state` console error on every soft nav. It's independent of this bug (search fix works regardless) and aborts the view-transition *animation* (falls back to instant swap). Tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
