### PR TITLE
PRDCT-348: fix code-vs-docs discrepancies in extractors/other

### DIFF
--- a/src/content/docs/components/extractors/other/airtable/index.md
+++ b/src/content/docs/components/extractors/other/airtable/index.md
@@ -23,13 +23,17 @@ Create an Airtable PAT token:
 1. [Create a new configuration](/components/#creating-component-configuration) of the Airtable data source.
 2. In the authorization section, enter the obtained PAT token. See the [Prerequisites](#prerequisites) section.
 3. Create a new configuration row.
-4. Select a base ID. To reload available bases, click the **Reload Available Base IDs** button.
-5. Select the table you wish to sync. To reload available tables for the selected base, click the **Reload Available Tables** button.
-6. Optionally, insert a custom filter formula. For syntax, please refer [here](https://support.airtable.com/docs/formula-field-reference), e.g., `DATETIME_DIFF(NOW(), CREATED_TIME(), 'minutes') < 130`
-7. Optionally, select a subset of fields you wish to sync. If left empty, all fields are downloaded.
-8. Configure the Destination section:
-    1. Optionally, set the resulting Storage Table Name. If left empty, the name of the source table will be automatically used.
-    2. Select Load Type. If full load is used, the destination table will be overwritten with every run. If incremental load is used, data will be “upserted“ into the destination table.
+4. Select a **Base ID**. To reload available bases, click the **Reload Available Base IDs** button.
+5. Select the **Table** you wish to sync. To reload available tables for the selected base, click the **Reload Available Tables** button.
+6. Optionally, enable **Use View** to extract data from a specific Airtable view instead of the entire table. When checked, select the desired **View Name** from the dropdown.
+7. Optionally, select a subset of **Fields** you wish to sync. If left empty, all fields are downloaded. Note: when using a view, even hidden fields will be retrieved.
+8. Configure the **Sync Options**:
+    - **Sync Mode** -- choose `Full Sync` (downloads all data every run) or `Incremental Sync` (downloads data created or updated in the specified time range using `CREATED_TIME()` or `LAST_MODIFIED_TIME()` fields; see [Airtable formula field reference](https://support.airtable.com/docs/formula-field-reference)).
+    - **Date From** (incremental only) -- date from which data is downloaded. Either a date in `YYYY-MM-DD` format or a dateparser string (e.g., `5 days ago`, `1 month ago`, `yesterday`). You can also use `last run` to fetch data from the last component run. Default: `last run`.
+    - **Date To** (incremental only) -- date to which data is downloaded. Either a date in `YYYY-MM-DD` format or a dateparser string (e.g., `5 days ago`, `now`). Default: `now`.
+9. Configure the **Destination** section:
+    1. Optionally, set the resulting **Storage Table Name**. If left empty, the name of the source table will be automatically used.
+    2. Select **Load Type**. If full load is used, the destination table will be overwritten with every run. If incremental load is used, data will be upserted into the destination table.
 
 ![Screenshot - Row](/components/extractors/other/airtable/config_row.png)
 

--- a/src/content/docs/components/extractors/other/aws-cur-reports/index.md
+++ b/src/content/docs/components/extractors/other/aws-cur-reports/index.md
@@ -46,7 +46,7 @@ Now fill in the extraction configuration parameters:
 **Note** that when checked, the `Maximum date` parameter is ignored.
 - **Minimum date** -- lowest report date to download. When `New files only` is checked, this applies only on the first run, reset the state to backfill. 
 Date in `YYYY-MM-DD` format or a string, i.e., `5 days ago`, `1 month ago`, `yesterday`, etc. If left empty, all records will be downloaded. 
-- **Maximum date** -- lowest report date to download. When `New files only` is checked, this applies only on the first run, reset the state to backfill. 
+- **Maximum date** -- highest report date to download.
 Date in `YYYY-MM-DD` format or a string, i.e., `5 days ago`, `1 month ago`, `yesterday`, etc. If left empty, all records will be downloaded. 
 - **Report prefix** -- the prefix as you set up in the AWS CUR config. 
 In the S3 bucket, this is path to your report. E.g., `my-report` or `some/long/prefix/my_report`. 

--- a/src/content/docs/components/extractors/other/azure-cost/index.md
+++ b/src/content/docs/components/extractors/other/azure-cost/index.md
@@ -36,7 +36,7 @@ This way you can import new data, e.g., from today, without deleting the data im
 ## Output Table
 
 The output table contains the following columns:
-- Time dimension, if enabled; art of the primary key
+- Time dimension, if enabled; part of the primary key
 - Columns from the grouping dimension; part of the primary key
 - **Cost**/**Usage** column
 - **Currency** column

--- a/src/content/docs/components/extractors/other/azure-cost/index.md
+++ b/src/content/docs/components/extractors/other/azure-cost/index.md
@@ -22,16 +22,25 @@ Fill in the **name**, and, optionally, the **description**. Then click **Add Row
 
 ![Screenshot - Add Row Modal](/components/extractors/other/azure-cost/modal.png)
 
-In the [Configuration Row](/components/#configuration-rows) fill in 
+In the [Configuration Row](/components/#configuration-rows) fill in:
+
 - **Destination Table** -- the name of the table in the project's bucket where the results are written.
-- **Grouping Dimension** -- the columns you are targeting.
-- **Time Frame** -- the predefined or custom time frame.
-- And, optionally, other fields. 
+- **Type** -- the cost data type: `ActualCost` (default), `AmortizedCost`, or `Usage`.
+- **Aggregation** -- the cost metric to aggregate: `Cost` (default), `CostUSD`, `PreTaxCostUSD`, `UsageQuantity`, or `PreTaxCost`.
+- **Granularity** -- time granularity of the results: `Daily` (default), `Monthly`, or `None`.
+- **Grouping Dimension** -- one or more columns to group costs by. Available values: `ServiceName`, `ResourceGroupName`, `ResourceLocation`, `ResourceType`, `ResourceId`, `MeterCategory`, `MeterSubCategory`, `Meter`, `ServiceTier`, `BillingPeriod`, `InvoiceNumber`, `PartNumber`, `PricingModel`, `ChargeType`, `PublisherType`, `ReservationId`, `ReservationName`, `Frequency`, `ResourceGuid`.
+- **Time Frame** -- the predefined or custom time frame: `WeekToDate`, `MonthToDate` (default), `BillingMonthToDate`, `TheLastMonth`, `TheLastBillingMonth`, or `Custom`. When `Custom` is selected, specify a **Start** and **End** date in `YYYY-MM-DD` format.
 
 ![Screenshot - Configuration Row](/components/extractors/other/azure-cost/row.png)
 
-If the [**Incremental Load**](/storage/tables/#incremental-loading) is set to true, the new data will be appended to the old ones. 
+If the [**Incremental Load**](/storage/tables/#incremental-loading) is set to true, the new data will be appended to the old ones.
 This way you can import new data, e.g., from today, without deleting the data imported before.
+
+### Authentication
+The connector supports two authentication methods:
+
+- **OAuth** -- click **Authorize Account** to authorize with your Azure account. You can optionally specify a **Tenant ID** to restrict authorization to a specific Azure AD tenant.
+- **Service Principal** -- provide `tenant`, `username`, and `password` credentials for a registered Azure AD application. This method is useful for automated or headless scenarios.
 
 ## Output Table
 

--- a/src/content/docs/components/extractors/other/dynamodb-streams/index.md
+++ b/src/content/docs/components/extractors/other/dynamodb-streams/index.md
@@ -30,7 +30,7 @@ Fill in the following parameters:
 - **Table Name** (table) - [REQ] DynamoDB Table Name
 - **Attributes** (attributes) - [OPT] Comma separated list of attributes
 
-![Screenshot - DynamoDB Streams Confguration](/components/extractors/other/dynamodb-streams/dynamodb-streams.png)
+![Screenshot - DynamoDB Streams Configuration](/components/extractors/other/dynamodb-streams/dynamodb-streams.png)
 
 When done, **save** the configuration. 
 

--- a/src/content/docs/components/extractors/other/geocoding-augmentation/index.md
+++ b/src/content/docs/components/extractors/other/geocoding-augmentation/index.md
@@ -48,7 +48,7 @@ The following are the available providers that will be queried for the data:
 - **google_maps** - [Google Maps](https://developers.google.com/maps/documentation/geocoding/intro) provider, needs parameter **apiKey** with your access key to the API (you need "Server" type of key).
 - **google_maps_business** - [Google Maps](https://developers.google.com/maps/premium/faq#getting_started) for Business provider, needs parameters **clientId** and **privateKey**.
 - **bing_maps** - [Bing Maps](https://docs.microsoft.com/en-us/bingmaps/spatial-data-services/geocode-dataflow-api/?redirectedfrom=MSDN) provider, needs attribute **apiKey**.
-- **yandex** - [Yandex](https://tech.yandex.com/maps/geocoder/doc/desc/concepts/about-docpage/) provider, needs attribute apiKey; locale parameter may be one of these values: uk-UA, be-BY, en-US, en-BR, tr-TR.
+- **yandex** - [Yandex](https://tech.yandex.com/maps/geocoder/doc/desc/concepts/about-docpage/) provider, does not need any API key; locale parameter may be one of these values: uk-UA, be-BY, en-US, en-BR, tr-TR.
 - **map_quest** - [MapQuest](https://developer.mapquest.com/documentation/geocoding-api/) provider, needs parameter **apiKey**.
 - **tomtom** - [TomTom](https://www.programmableweb.com/api/tomtom-geocoding) provider, needs parameter **apiKey**, parameter locale may have one of these values: de, es, fr, it, nl, pl, pt, sv.
 - **opencage**: [OpenCage](https://opencagedata.com/) provider, needs parameter **apiKey**.

--- a/src/content/docs/components/extractors/other/geocoding-augmentation/index.md
+++ b/src/content/docs/components/extractors/other/geocoding-augmentation/index.md
@@ -22,7 +22,7 @@ edit the [input mapping](/transformations/mappings/#input-mapping) details accor
 You can test the extraction on this [sample file](/components/extractors/other/geocoding-augmentation/locations.csv). 
 Upload it to the `in.c-main` bucket in Storage first and call it `locations`.
 Specify a single table in the [output mapping](/transformations/mappings/#output-mapping) 
-and select the **geocode** method in the configuration. You can use the `openstreetmap` provider for free.
+and select the **geocode** method in the configuration. You can use the `nominatim` provider for free.
 (The names of the input and CSV files are arbitrary, and so are the names of the columns.)
 
 ![Screenshot - Add coordinates to locations](/components/extractors/other/geocoding-augmentation/geocoding-1.png)
@@ -52,4 +52,4 @@ The following are the available providers that will be queried for the data:
 - **map_quest** - [MapQuest](https://developer.mapquest.com/documentation/geocoding-api/) provider, needs parameter **apiKey**.
 - **tomtom** - [TomTom](https://www.programmableweb.com/api/tomtom-geocoding) provider, needs parameter **apiKey**, parameter locale may have one of these values: de, es, fr, it, nl, pl, pt, sv.
 - **opencage**: [OpenCage](https://opencagedata.com/) provider, needs parameter **apiKey**.
-- **openstreetmap**: [OpenStreetMap](https://wiki.openstreetmap.org/wiki/Nominatim) provider, does not need any API key.
+- **nominatim**: [OpenStreetMap / Nominatim](https://wiki.openstreetmap.org/wiki/Nominatim) provider, does not need any API key.

--- a/src/content/docs/components/extractors/other/github/index.md
+++ b/src/content/docs/components/extractors/other/github/index.md
@@ -12,22 +12,29 @@ to Keboola.
 
 ## Configuration
 [Create a new configuration](/components/#creating-component-configuration) of the **GitHub** connector.
-Then click **Authorize Account** to [authorize the configuration](/components/#authorization), and
-select the template you wish to use. There are two configuration templates available:
 
-- `Smart Mode` -- always gets missing data only, loads data [incrementally](/storage/tables/#incremental-loading).
-- `Full Mode` -- always gets everything.
+### Authentication
+In the authorization section, enter a **GitHub Personal Access Token (PAT)** with the required scopes: `read:org` and `repo`.
+You can create a PAT in [GitHub Settings > Developer settings > Personal access tokens](https://github.com/settings/tokens).
 
-![Screenshot - GitHub configuration](/components/extractors/other/github/github-1.png)
+### Endpoints
+Select one or more **Endpoints to Extract**:
 
-You can download:
+- `organizations` -- your GitHub organizations
+- `organization_members` -- members of your organizations
+- `organization_teams` -- teams within your organizations
+- `organization_repositories` -- repositories owned by your organizations
+- `repository_issues` -- issues in a repository
+- `repository_commits` -- commits in a repository
 
-- Your Organizations
-- Organization Members
-- Organization Teams
-- Organization Repositories
-- Repository Issues
-- Repository Commits
+### Row Configuration
+Click **Add Row** to add one or more [configuration rows](/components/#configuration-rows).
+Each row specifies the scope of extraction:
 
-After you select the template, remember to **save** the configuration.
-You can also [switch to the JSON editor](/components/extractors/other/generic/#template-mode).
+- **Organization Name** -- GitHub organization name (required for organization-related endpoints).
+- **Repository Owner** -- repository owner username or organization name (required for repository-specific endpoints).
+- **Repository Name** -- repository name (required for repository-specific endpoints).
+- **Issue State** -- filter issues by state: `all` (default), `open`, or `closed` (for the `repository_issues` endpoint).
+- **Commits Since** -- only fetch commits after this date in ISO 8601 format (e.g., `2024-01-01T00:00:00Z`). Leave empty for all commits (for the `repository_commits` endpoint).
+
+Remember to **save** the configuration.

--- a/src/content/docs/components/extractors/other/google-search-console/index.md
+++ b/src/content/docs/components/extractors/other/google-search-console/index.md
@@ -16,7 +16,10 @@ endpoint.
 
 ## Configuration
 [Create a new configuration](/components/#creating-component-configuration) of the **Google Search Console** connector.
-Then click **Authorize Account** to [authorize the configuration](/components/#authorization).
+Then authorize the configuration using one of the supported methods:
+
+- **OAuth** -- click **Authorize Account** to [authorize the configuration](/components/#authorization) with your Google account.
+- **Service Account** -- enable **Use Service Account** and paste the service account JSON credentials into the provided field. This method is useful for automated or headless scenarios.
 
 ![Screenshot - Component Config](/components/extractors/other/google-search-console/auth.png)
 
@@ -32,6 +35,7 @@ To extract a search analytics report, select the "Search analytics" endpoint.
 ![Screenshot - Search analytics Config](/components/extractors/other/google-search-console/row_config.png)
 
 - Fill in the domain to extract data from; if the domain has data across all URL variations under the domain, enter it as sc-domain:domainname.com. It should not contain "https://www." before the domain name.
+- Optionally, specify a **Type** to filter results by search type: `web`, `image`, `video`, `news`, `discover`, or `googleNews`.
 - Fill in the dimensions you wish to extract data from. Possible dimensions are country, device, page, query, and searchAppearance (searchAppearance cannot be combined with other fields).
 - Select a date range to extract data from, either set dynamic date ranges, such as last week or last month or a custom date range where you specify a date from and date to. Custom dates can be filled in with the following:
     - Relative dates like: '1 min ago', '2 weeks ago', '3 months, 1 week and 1 day ago', 'in 2 days', 'tomorrow'.
@@ -46,6 +50,7 @@ To extract a search analytics report, select the "Search analytics" endpoint.
 ![Screenshot - Search analytics Config](/components/extractors/other/google-search-console/filter1.png)
 
 - To create a new filter within a filter group, click the **Add Filter** button and specify the dimension, operator, and expression.
+- Optionally, enable **Include fresh data** to include preliminary data that may change later. See [Google's documentation on fresh data in Search Console](https://developers.google.com/search/blog/2019/09/search-performance-fresh-data) for details.
 
 When using filters, make sure to use the Incremental load option. Otherwise, there are possibilities for duplicate data.
 

--- a/src/content/docs/components/extractors/other/google-search-console/index.md
+++ b/src/content/docs/components/extractors/other/google-search-console/index.md
@@ -63,7 +63,7 @@ Click **Save** and run the configuration.
 
 ### Sitemaps Endpoint
 
-To extract a search analytics report, select the "Sitemaps" endpoint.
+To extract a sitemaps report, select the "Sitemaps" endpoint.
 
 ![Screenshot - Sitemaps Config](/components/extractors/other/google-search-console/row_config_sitemaps.png)
 

--- a/src/content/docs/components/extractors/other/hibob/index.md
+++ b/src/content/docs/components/extractors/other/hibob/index.md
@@ -25,7 +25,7 @@ Once you have acquired these credentials, you can proceed with the configuration
 1. [Create a new configuration](/components/#creating-component-configuration) for the HiBob connector.
 2. In the authorization section, enter the Service User ID and Service User Token.
 3. Select which endpoints you want to fetch.
-4. You have the option to set the `Human readable` parameter, which makes the API return object names instead of IDs.
+4. You have the option to set the `Human readable` parameter, which makes the API return object names instead of IDs. This option only affects the employees table.
 5. In the Destination settings, you can choose between `Full Load` and `Incremental Load`.
 If full load is used, the destination table will be overwritten with every run. If incremental load is used, data will be upserted into the destination table.
 

--- a/src/content/docs/components/extractors/other/mapbox/index.md
+++ b/src/content/docs/components/extractors/other/mapbox/index.md
@@ -50,7 +50,7 @@ For more information on the Matrix API, see the official [Matrix API documentati
 | Parameter | Description |
 |---|---|
 | Routing profile | Profile for calculating duration or distance |
-| Source coordinates columns | Names of columns with in the input table with [decimal degree](https://en.wikipedia.org/wiki/Decimal_degrees) coordinates |
+| Source coordinates columns | Names of columns in the input table with [decimal degree](https://en.wikipedia.org/wiki/Decimal_degrees) coordinates |
 | Destination coordinates column | Column containing up to 24 longitude, latitude coordinates separated by semicolons, e.g., 14.538, 50.053; 13.538, 49.053 |
 | Annotations | Choose duration, distance, or both |
 | Destination table name (optional) | Name of the output table, defaults to configuration ID + endpoint name if not specified | 

--- a/src/content/docs/components/extractors/other/pingdom/index.md
+++ b/src/content/docs/components/extractors/other/pingdom/index.md
@@ -45,7 +45,7 @@ Provide credentials of your Pingdom account and the Application Key.
 Choose the **period** you want to fetch data for.
 
 - `Last 24 hours`
-- `Last 3O days` -- *Pingdom API provides history only for up to 30 days before the current day*
+- `Last 30 days` -- *Pingdom API provides history only for up to 30 days before the current day*
 
 And finally, select the data **Basic** template and click on **Save**.
 You can also [switch to the JSON editor](/components/extractors/other/generic/#template-mode).

--- a/src/content/docs/components/extractors/other/servicenow/index.md
+++ b/src/content/docs/components/extractors/other/servicenow/index.md
@@ -33,7 +33,7 @@ The user is authenticated using:
  - **Sysparm Fields** (sysparm_fields) - [OPT] Using this parameter you can limit fetched fields. Please use comma separation.
  - **Increment** (increment) - [OPT] Set this parameter to true if you want to do incremental load.
 
-![Screenshot - DynamoDB Streams Configuration](/components/extractors/other/servicenow/servicenow_tables_1.png)
+![Screenshot - ServiceNow Configuration](/components/extractors/other/servicenow/servicenow_tables_1.png)
 
 When done, **save** the configuration. 
 

--- a/src/content/docs/components/extractors/other/time-doctor-2/index.md
+++ b/src/content/docs/components/extractors/other/time-doctor-2/index.md
@@ -29,12 +29,12 @@ that the companies endpoint will return.
 
 ### Endpoints
 
- - `users` – [OPT] ***this endpoint is required for the processing worklog, edit-time and timeuse endpoints***
+ - `users` -- [OPT] ***this endpoint is required for the processing worklog, edit-time and timeuse endpoints***
  - `worklog` -- [OPT] fetches data from the [worklog](https://api2.timedoctor.com/#/Activity/getActivityWorklog) endpoint
  - `edit-time` -- [OPT] fetches data from the [edit-time](https://api2.timedoctor.com/#/Activity/getActivityEditTime) endpoint
- - `timeuse` – [OPT] fetches data from the [timeuse](https://api2.timedoctor.com/#/Activity/getActivityTimeuse) endpoint
- - `projects` – [OPT] fetches data from the [projects](https://api2.timedoctor.com/#/Projects/projects) endpoint
- - `tasks` – [OPT] fetches data from the [tasks](https://api2.timedoctor.com/#/Tasks/tasks) endpoint
+ - `timeuse` -- [OPT] fetches data from the [timeuse](https://api2.timedoctor.com/#/Activity/getActivityTimeuse) endpoint
+ - `projects` -- [OPT] fetches data from the [projects](https://api2.timedoctor.com/#/Projects/projects) endpoint
+ - `tasks` -- [OPT] fetches data from the [tasks](https://api2.timedoctor.com/#/Tasks/tasks) endpoint
 
 ### Additional Settings
 

--- a/src/content/docs/components/extractors/other/time-doctor-2/index.md
+++ b/src/content/docs/components/extractors/other/time-doctor-2/index.md
@@ -30,15 +30,15 @@ that the companies endpoint will return.
 ### Endpoints
 
  - `users` – [OPT] ***this endpoint is required for the processing worklog, edit-time and timeuse endpoints***
- - `worklog`–– [OPT] fetches data from the [worklog](https://api2.timedoctor.com/#/Activity/getActivityWorklog) endpoint
- - `edit-–ime` – [OPT] fetches data from the [edit-time](https://api2.timedoctor.com/#/Activity/getActivityEditTime) endpoint
+ - `worklog` -- [OPT] fetches data from the [worklog](https://api2.timedoctor.com/#/Activity/getActivityWorklog) endpoint
+ - `edit-time` -- [OPT] fetches data from the [edit-time](https://api2.timedoctor.com/#/Activity/getActivityEditTime) endpoint
  - `timeuse` – [OPT] fetches data from the [timeuse](https://api2.timedoctor.com/#/Activity/getActivityTimeuse) endpoint
  - `projects` – [OPT] fetches data from the [projects](https://api2.timedoctor.com/#/Projects/projects) endpoint
  - `tasks` – [OPT] fetches data from the [tasks](https://api2.timedoctor.com/#/Tasks/tasks) endpoint
 
 ### Additional Settings
 
- - `users` - [OPT] If set to false, the component will truncate data in the existing Keboola tables.
+ - `increment` -- [OPT] If set to false, the component will truncate data in the existing Keboola tables. Default: true.
 
 ![Screenshot - Time Doctor 2 Configuration](/components/extractors/other/time-doctor-2/time-doctor-2.png)
 

--- a/src/content/docs/components/extractors/other/weather-api/index.md
+++ b/src/content/docs/components/extractors/other/weather-api/index.md
@@ -26,9 +26,9 @@ Subscribe to the plan that fits your expected consumption.
       * Choose `Forecast` to obtain a forecast (use `Forecast days` to specify how many days ahead you want data for). 
       * Choose `History` to retrieve historical data. Use `Historical Date` to specify the period in the past.
     * **Location Query** (location_query): A query parameter for location. It can be latitude and longitude in decimal degrees, e.g., 48.8567,2.3508, a city name, e.g., Paris, or even an IP address like `100.0.0.1`. Learn more in the [documentation](https://www.weatherapi.com/docs/).
-    * **Forecast Days** (forecast_days): The number of forecast days required.
+    * **Forecast Days** (forecast_days): The number of forecast days required (1--14).
     * **Historical Date** (historical_date): The date from which to fetch historical data, either in `YYYY-MM-DD` format or a relative date like `last week`.
-    * **Continue On Failure** (continue_on_failure): A Boolean value. If set to `True`, the process will continue dispite fetching errors, and failed responses will be saved in the `failed_fetches.csv` file. 
+    * **Continue On Failure** (continue_on_failure): Available only when using an input table. A Boolean value. If set to `True`, the process will continue despite fetching errors, and failed responses will be saved in the `failed_fetches.csv` file. 
   If set to `False`, the component run will terminate with an error as soon as one request fails.
 * **Destination Settings** (destination_settings)
     * **Load Type** (load_type): If full load is selected, the destination table will be overwritten with every run. If incremental load is used, data will be upserted into the existing destination table. Full load overwrites the destination table each time.
@@ -49,4 +49,4 @@ There are four output tables:
 - `weather_astronomical.csv`: Contains daily historical and future astronomical data.
 - `weather_daily.csv`: Contains daily forecasts and historical data.
 - `weather_hourly.csv`: Contains hourly forecasts and historical data.
-- `failed_fetches.csv`: If the 'continue on failure' parameter is set to `true`, this table will record any errors that occurr during data fetching.
+- `failed_fetches.csv`: If the 'continue on failure' parameter is set to `true`, this table will record any errors that occur during data fetching.

--- a/src/content/docs/components/extractors/other/what3words/index.md
+++ b/src/content/docs/components/extractors/other/what3words/index.md
@@ -14,6 +14,8 @@ Notice that each translated address requires one API call.
 ## Configuration
 [Create a new configuration](/components/#creating-component-configuration) of the **What3words Augmentation** connector.
 
+In the configuration, you can optionally set the **Language** parameter (`lang`) to control the language of the API response. Default: `en`. See the [what3words API documentation](https://developer.what3words.com/public-api/docsv2) for supported language codes.
+
 ## Augment What3words Address
 In this mode of operation, you identify [what3words](https://what3words.com/about) addresses, and the connector
 then fetches the geographical latitude and longitude coordinates for the places. 

--- a/src/content/docs/components/extractors/other/yourpass/index.md
+++ b/src/content/docs/components/extractors/other/yourpass/index.md
@@ -13,7 +13,7 @@ The YourPass data source connector uses the [YourPass API](https://doc.yourpass.
 to Keboola.
 
 ## Configuration
-[Create a new configuration](/components/#creating-component-configuration) of the **YourPasss** connector.
+[Create a new configuration](/components/#creating-component-configuration) of the **YourPass** connector.
 
 ### Authorization Configuration
 
@@ -47,6 +47,6 @@ Select one of the following two load types:
 - `Full Load` -- overwrites the destination table each time.
 
 You can set the primary keys by clicking the button **Add Primary Key Column** and adding multiple keys if required.
-You can delete primary keys by clicking the button **Delete Primary Key Column**. Just make sure to delete the output tale 
+You can delete primary keys by clicking the button **Delete Primary Key Column**. Just make sure to delete the output table 
 in the storage before deleting primary keys, as the output table always expects the list of primary keys to stay constant.
 


### PR DESCRIPTION
Jira issue(s): [PRDCT-348](https://linear.app/keboola/issue/PRDCT-348/componentsextractorsother)

Changes:

Code-vs-docs audit of all 23 connectors under `components/extractors/other`. Compared documented fields, options, defaults, limits and behavior against source code schemas (`configSchema.json`, `configRowSchema.json`, PHP `ConfigDefinition`). 20 findings total across 12 connectors with source access.

### Code-accuracy fixes (schema evidence cited)

**Airtable** — removed non-existent `filter_by_formula` UI field; added `use_view`/`view_name` params; added `sync_options` (`sync_mode`, `date_from`, `date_to`)
  - Evidence: `component-airtable/component_config/configRowSchema.json:47-69, 90-137`

**GitHub** — rewrote entire config section: docs described v1 Generic Extractor (OAuth + templates); deployed component is `keboola.ex-github-v2` (PAT + endpoint multiselect + row config with `organization_name`, `repository_owner`, `repository_name`, `issue_state`, `commits_since`)
  - Evidence: `component-github/component_config/configSchema.json`, `configRowSchema.json`

**Azure Cost Management** — added `type` (ActualCost/AmortizedCost/Usage), `aggregation` (5 values), `granularity` (None/Daily/Monthly); enumerated all 19 grouping dimension values and 6 time frame options; documented Service Principal auth
  - Evidence: `ex-azure-cost-management/src/ConfigDefinition.php:16-89`

**Google Search Console** — added `search_type` filter, `include_fresh` option, service account auth
  - Evidence: `component-google-search-console/component_config/configRowSchema.json:37-46, 87-98, 183-199`

**Geocoding Augmentation** — fixed provider name `openstreetmap` → `nominatim`; fixed Yandex apiKey claim (code passes no key)
  - Evidence: `geocoding-augmentation/src/.../Augmentation.php:224-236`, `ParametersValidation.php:50-52`

**What3words** — added undocumented `lang` parameter (default `en`)
  - Evidence: `app-what3words/main.php:38-42`

**AWS CUR Reports** — "lowest report date" → "highest" (copy-paste from Minimum date)
  - Evidence: `component-aws-cost-and-usage-reports/component_config/configSchema.json:133`

**Time Doctor 2** — parameter mislabeled `users` → actual name `increment`; fixed garbled `edit-–ime` → `edit-time`; normalized dash style across the endpoints list to `--`
  - Evidence: `component-time-doctor-2/component_config/configSchema.json:106-112`

**Weather API** — added `forecast_days` limit (1–14); clarified `continue_on_failure` only in input-table mode
  - Evidence: `component-weather-api/component_config/configSchema.json:84-85, 117-119`

**HiBob** — added scope clarification: `human_readable` only affects employees table
  - Evidence: `component-hibob/component_config/configSchema.json:54-58`

### Doc hygiene fixes (typos, alt-text)
- `yourpass`: "YourPasss" → "YourPass", "output tale" → "output table"
- `pingdom`: "Last 3O days" → "Last 30 days" (letter O → digit 0)
- `mapbox`: "columns with in" → "columns in"
- `dynamodb-streams`: alt text "Confguration" → "Configuration"
- `servicenow`: alt text "DynamoDB Streams Configuration" → "ServiceNow Configuration"
- `google-search-console`: "search analytics report" → "sitemaps report" in Sitemaps section
- `azure-cost`: "art of the primary key" → "part of"
- `weather-api`: "dispite" → "despite", "occurr" → "occur"
- `time-doctor-2`: normalized mixed en-dash/`--` style in endpoints list (per review nit)

---

11 connectors had no accessible source repo and could not be verified: DynamoDB Streams, Dark Sky, Currency Rates, Mapbox, Okta, ServiceNow, YourPass, Pingdom, Papertrail, Stripe, Generic Extractor.

**Note:** `github/index.md` v2 rewrite is now image-less — the old v1 screenshot no longer matches. A maintainer with UI access should capture a current `keboola.ex-github-v2` screenshot.

## Release Notes
**Justification, description**

Documentation accuracy fixes based on code-vs-docs audit of extractors/other connectors. Aligns documented fields, options, defaults, and behavior with actual component schemas.

**Plans for Customer Communication**

N/A — documentation-only changes.

**Impact Analysis**

No code changes. Documentation corrections only.

**Deployment Plan**

Merge to main → auto-deploy to help.keboola.com.

**Rollback Plan**

Revert PR.

**Post-Release Support Plan**

N/A

Link to Devin session: https://app.devin.ai/sessions/c360b6efa9804125940654b8cd841f3d
Requested by: @Iamfle4ka