### PR TITLE
fix(data-apps): code-accuracy audit safe fixes (PRDCT-358)

### DIFF
--- a/src/content/docs/data-apps/general-design-guide/index.md
+++ b/src/content/docs/data-apps/general-design-guide/index.md
@@ -13,7 +13,7 @@ and more to streamline your setup. With clear, step-by-step instructions, you'll
 ## Theming
 There are two options for setting theming:
 
-1. **Keboola Apps Interface:** Choose from predefined or custom themes directly in the Keboola interface. See more in [the documentation](/data-apps/#theming).
+1. **Keboola Apps Interface:** Choose from predefined or custom themes directly in the Keboola interface. See more in [the documentation](/data-apps/streamlit/#theming).
 2. **Configuration File:** Use the settings in the `config.toml` file, located in the `.streamlit` folder.
 
 ![Screenshot - Streamlit Folder](/data-apps/general-design-guide/pic1.png)
@@ -35,7 +35,7 @@ secondaryBackgroundColor="#edf0f5"
 Store the logo PNG image in the `/static/` repository folder (created automatically upon deployment in Keboola).
 
 ```
-LOGO_IMAGE_PATH = os.path.join(os.path.dirname(__file__), 'static/keboola.png"')
+LOGO_IMAGE_PATH = os.path.join(os.path.dirname(__file__), 'static/keboola.png')
 ```
 
 Position the logo on the left and disable the full-screen view for the image.

--- a/src/content/docs/data-apps/lock-streamlit-version/git-deployment/index.md
+++ b/src/content/docs/data-apps/lock-streamlit-version/git-deployment/index.md
@@ -76,5 +76,5 @@ Following these best practices will help you maintain a stable, efficient, and c
 
 - **Keep it clean:** Include only the necessary packages to keep the environment lightweight.
 - **Update regularly:** Periodically update and test dependencies in a development environment before generating a new `requirements.txt` file.
-- **Test locally:** Verify that your app works correctly with the locked package versions in a local environmnet before deploying it in Keboola.
+- **Test locally:** Verify that your app works correctly with the locked package versions in a local environment before deploying it in Keboola.
 - **Match environments:** Use the same Python version in your local setup with Keboola's version (Python 3.10) to prevent version mismatches.  

--- a/src/content/docs/data-apps/oidc/auth0/index.md
+++ b/src/content/docs/data-apps/oidc/auth0/index.md
@@ -39,7 +39,7 @@ Follow these steps to set up the authentication method for your app:
 - Under **Authentication**, select **OIDC** and then **Generic OIDC**.
 - Copy the client ID from your Auth0 application to the **Client ID** field in Keboola.
 - Copy the client secret from the Auth0 application to the **Client secret** field in Keboola.
-- In the **Issuer URL** field, enter `https://<yourDomain>.us.auth0.com/`, which is the correct issuer URL for Google OAuth 2.0.
+- In the **Issuer URL** field, enter `https://<yourDomain>.us.auth0.com/`, which is the correct issuer URL for Auth0.
 - Click **Save** to apply the changes.
 
 ## Step 4: Set Up the Auth0 Consent Screen

--- a/src/content/docs/data-apps/oidc/google-cloud-platform/index.md
+++ b/src/content/docs/data-apps/oidc/google-cloud-platform/index.md
@@ -60,7 +60,7 @@ Follow these steps to deploy your app in Keboola:
 - Click the green **Deploy App** button to deploy the application.
 
 ## Step 6: Test the App
-Follow these step to test your new app:
+Follow these steps to test your new app:
 
 - Go to the app's URL.
 - You should be redirected to the Google OAuth consent screen.

--- a/src/content/docs/data-apps/oidc/microsoft-entra-id/index.md
+++ b/src/content/docs/data-apps/oidc/microsoft-entra-id/index.md
@@ -70,5 +70,5 @@ Follow these steps to test your new app:
 
 - Go to the app's URL.
 - You should be asked to log in using your Entra ID account.
-- After successfully loging in, you will be redirected to the app.
+- After successfully logging in, you will be redirected to the app.
 - The app should display its content.

--- a/src/content/docs/data-apps/streamlit/index.md
+++ b/src/content/docs/data-apps/streamlit/index.md
@@ -51,7 +51,7 @@ There are two ways to deploy a Streamlit app:
 
 ### Code
 
-For simple use cases where your Streamlit code fits on one page, paste the code directly into a text area. This deployment type is ideal for simple apps or for testing. Check out [this example from Streamlit docs](https://docs.streamlit.io/library/get-started/create-an-app#lets-put-it-all-together).
+For simple use cases where your Streamlit code fits on one page, paste the code directly into a text area. This deployment type is ideal for simple apps or for testing. Check out [this example from Streamlit docs](https://docs.streamlit.io/get-started/tutorials/create-an-app).
 
 ![Code deployment](/data-apps/streamlit/development-type-code.png)
 ![Hello World code](/data-apps/streamlit/hello-world-code.png)
@@ -89,7 +89,7 @@ To provide your app with environment variables or sensitive information like cre
 
 When you upload `secrets.toml` using the direct secrets upload UI, Keboola imports secrets as flat, top-level keys. Sections (TOML groups) are not preserved as nested structures. This means keys in the file become `st.secrets["your_key"]` after upload - you cannot access them as `st.secrets["group"]["key"]`. If your app expects nested secrets, use repo-based secrets.
 
-[Read more about the Streamlit secrets](https://docs.streamlit.io/streamlit-community-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+[Read more about the Streamlit secrets](https://docs.streamlit.io/deploy/streamlit-community-cloud/deploy-your-app/secrets-management).
 
 ### Direct Secrets Upload
 You can upload a `secrets.toml` file directly through the UI when developing an app from code. The upload process:
@@ -117,7 +117,7 @@ By default, there are two environment variables available that make it easy to a
 - `KBC_URL`: This represents the URL of the current Keboola project.
 - `KBC_TOKEN`: This represents the Storage token with full read-write access to Keboola Storage.
 
-To securely access Storage, we recommend creating a dedicated Storage token with limited permissions and passing it to your app as a secret. You can generate such a token following the [guide here](https://help.keboola.com/management/project/tokens/).
+To securely access Storage, we recommend creating a dedicated Storage token with limited permissions and passing it to your app as a secret. You can generate such a token following the [guide here](/management/project/tokens/).
 
 **Important:**
 Do not name your secret `KBC_TOKEN`, as this name is reserved.
@@ -133,7 +133,7 @@ client = Client(kbc_url, kbc_token)
 These variables represent the project where the application is deployed. To map data from a different project, you need to configure the appropriate secrets.
 
 ## Loading Data from Storage
-To load data from the Storage of a Keboola project into the app, use the [input mapping](https://help.keboola.com/transformations/mappings/#input-mapping) section. Just select your table in the input mapping section and navigate to that by `/data/in/tables/your_data.csv` or `/data/in/files/fileID_FileName.*` in your code. Note that the app needs to be redeployed to fetch up-to-date data. Or you can use the [Keboola Storage Python Client](https://github.com/keboola/sapi-python-client) in the app to load the data as needed.
+To load data from the Storage of a Keboola project into the app, use the [input mapping](/transformations/mappings/#input-mapping) section. Just select your table in the input mapping section and navigate to that by `/data/in/tables/your_data.csv` or `/data/in/files/fileID_FileName.*` in your code. Note that the app needs to be redeployed to fetch up-to-date data. Or you can use the [Keboola Storage Python Client](https://github.com/keboola/sapi-python-client) in the app to load the data as needed.
 
 ## Writing Back to Storage
 For writing data back to Keboola Project Storage, use the [Keboola Storage Python Client](https://github.com/keboola/sapi-python-client).


### PR DESCRIPTION
Fixes PRDCT-358

Changes:

- **Auth0 OIDC page**: Fix copy-paste error — said "correct issuer URL for Google OAuth 2.0" on the Auth0 page; corrected to "Auth0"
- **Design guide**: Fix broken anchor `/data-apps/#theming` → `/data-apps/streamlit/#theming` (no `#theming` heading exists on the index page)
- **Design guide**: Fix mismatched quotes in Python string literal (`'static/keboola.png"'` → `'static/keboola.png'`)
- **Streamlit page**: Update two stale Streamlit docs URLs that return 301 redirects to their current paths
- **Streamlit page**: Convert two absolute `help.keboola.com` links to root-relative paths per AGENTS.md conventions
- **Microsoft Entra ID page**: Fix typo "loging" → "logging"
- **Google Cloud Platform page**: Fix typo "these step" → "these steps"
- **Git deployment page**: Fix typo "environmnet" → "environment"

---

All fixes are unambiguous hygiene/accuracy corrections. No content restructuring, no config field changes, no needs_human items. Build passes cleanly.

Full audit log with Diátaxis classification posted to [PRDCT-358](https://linear.app/keboola/issue/PRDCT-358/data-apps).

Link to Devin session: https://app.devin.ai/sessions/42b064d3ee0a44a3839deded7a20d83b
Requested by: @Iamfle4ka