### PR TITLE
docs(data-streams): clarify no primary key support

### DIFF
--- a/src/content/docs/storage/data-streams/data-streams.md
+++ b/src/content/docs/storage/data-streams/data-streams.md
@@ -51,11 +51,23 @@ In your table settings, you can:
 - Change the name of the stream.
 - Add a column or define your own structure using the PATH or JSONNET template. [Learn more](https://developers.keboola.com/integrate/data-streams/overview/#template-jsonnet)
 - Edit column names (available only if you create a new table within the stream).
-- Edit primary keys (available only if you create a new table within the stream).
 - Delete a column (available only if you create a new table within the stream).
 
 :::caution
 **Important:** Changing the table's name will create a new table, and the stream will import data into that table.
+:::
+
+:::note[No primary key support]
+Data streams do **not** support primary keys --- every incoming event is **appended** to the
+table and no deduplication happens on import.
+
+If you need unique rows (e.g., one row per event ID), it is up to you to decide whether
+deduplication is required and to handle it **downstream**: create a
+[deduplication transformation](/storage/tables/#primary-key-deduplication) that reads the stream
+table and writes the result to a new table where the
+[output mapping](/transformations/mappings/#output-mapping) primary key performs the
+deduplication on load. Schedule it to run regularly with a [conditional flow](/flows/).
+[Kai](/kai/) can help you build both the transformation and the scheduled flow.
 :::
 
 #### Sample codes for integration


### PR DESCRIPTION
Jira issue(s): PROOF-XXX

Clarifies that **data streams do not support primary keys** — incoming events are appended and no deduplication happens on import. This was misleading before: the Table settings listed an "Edit primary keys" option, implying PK enforcement that does not exist.

Changes:

- Add a standalone **No primary key support** note explaining streams append every event with no import-time dedup
- Document the recommended workaround: a downstream [deduplication transformation](https://help.keboola.com/storage/tables/#primary-key-deduplication) writing to a new table (output-mapping PK dedups on load), scheduled via a [conditional flow](https://help.keboola.com/flows/), with Kai assistance
- Remove the misleading "Edit primary keys (available only if you create a new table within the stream)" bullet from Table settings

---

Docs-only change. Verified locally with `npm run dev` (page renders 200, all internal links resolve).