### PR TITLE
PRDCT-383: add llms.txt AI layer (+ pin markdown-remark)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 import starlightImageZoom from 'starlight-image-zoom';
+import starlightLlmsTxt from 'starlight-llms-txt';
 import { sidebar } from './src/sidebar.mjs';
 import redirectFrom from './src/integrations/redirect-from.mjs';
 import beaconTransforms from './src/integrations/beacon-transforms.mjs';
@@ -26,7 +27,35 @@ export default defineConfig({
         dark: './src/assets/logo-dark.png',
         replacesTitle: true,
       },
-      plugins: [starlightImageZoom()],
+      plugins: [
+        starlightImageZoom(),
+        // Generates /llms.txt, /llms-full.txt, /llms-small.txt at build time
+        // (llmstxt.org standard) so external AI agents and our own Ask Kai RAG
+        // get a curated, structured entrypoint to the docs.
+        starlightLlmsTxt({
+          projectName: 'Keboola Documentation',
+          description:
+            'Keboola is a data platform as a service. The documentation covers ' +
+            'Storage (tables, buckets, files), Transformations (SQL, Python, R, ' +
+            'dbt), Components (data source and destination connectors), Flows ' +
+            '(orchestration), and platform administration.',
+          // Float the section indexes and the Diátaxis Transformations pilot to
+          // the top of the generated output.
+          promote: ['index*', 'transformations/**'],
+          // Trim the small variant of the noisiest deep-reference pages.
+          exclude: ['404', '**/report-presets-columns-and-pk/**'],
+          // Let agents pull a single product domain at a time.
+          customSets: [
+            {
+              label: 'Transformations',
+              paths: ['transformations/**'],
+              description:
+                'SQL, Python, R, and dbt transformations — how-to guides, ' +
+                'reference, and concepts (Diátaxis-structured).',
+            },
+          ],
+        }),
+      ],
       customCss: ['./src/styles/custom.css'],
       head: [
         // GTM head script — only fires on help.keboola.com (not localhost/preview)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "astro": "^6",
         "marked": "^18.0.4",
         "sharp": "^0.33",
-        "starlight-image-zoom": "^0.14"
+        "starlight-image-zoom": "^0.14",
+        "starlight-llms-txt": "^0.10.0"
       },
       "devDependencies": {
         "@vercel/node": "^5.8.4",
@@ -26,26 +27,32 @@
       "license": "MIT"
     },
     "node_modules/@astrojs/internal-helpers": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.8.0.tgz",
-      "integrity": "sha512-J56GrhEiV+4dmrGLPNOl2pZjpHXAndWVyiVDYGDuw6MWKpBSEMLdFxHzeM/6sqaknw9M+HFfHZAcvi3OfT3D/w==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.0.tgz",
+      "integrity": "sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==",
       "license": "MIT",
       "dependencies": {
-        "picomatch": "^4.0.3"
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "js-yaml": "^4.1.1",
+        "picomatch": "^4.0.4",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5"
       }
     },
     "node_modules/@astrojs/markdown-remark": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.0.1.tgz",
-      "integrity": "sha512-zAfLJmn07u9SlDNNHTpjv0RT4F8D4k54NR7ReRas8CO4OeGoqSvOuKwqCFg2/cqN3wHwdWlK/7Yv/lMXlhVIaw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.0.tgz",
+      "integrity": "sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.8.0",
-        "@astrojs/prism": "4.0.1",
+        "@astrojs/internal-helpers": "0.10.0",
+        "@astrojs/prism": "4.0.2",
         "github-slugger": "^2.0.0",
         "hast-util-from-html": "^2.0.3",
         "hast-util-to-text": "^4.0.2",
-        "js-yaml": "^4.1.1",
         "mdast-util-definitions": "^6.0.0",
         "rehype-raw": "^7.0.0",
         "rehype-stringify": "^10.0.1",
@@ -53,8 +60,6 @@
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
         "remark-smartypants": "^3.0.2",
-        "shiki": "^4.0.0",
-        "smol-toml": "^1.6.0",
         "unified": "^11.0.5",
         "unist-util-remove-position": "^5.0.0",
         "unist-util-visit": "^5.1.0",
@@ -63,12 +68,12 @@
       }
     },
     "node_modules/@astrojs/mdx": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-5.0.2.tgz",
-      "integrity": "sha512-0as6odPH9ZQhS3pdH9dWmVOwgXuDtytJiE4VvYgR0lSFBvF4PSTyE0HdODHm/d7dBghvWTPc2bQaBm4y4nTBNw==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-5.0.6.tgz",
+      "integrity": "sha512-4dKe0ZMmqujofPNDHahzClkwinn9f8jHPcaXcgdGvPAlboD2mjzkUCofli2cBnxYAkdfhC6d50gBJ8i/cH8gHw==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/markdown-remark": "7.0.1",
+        "@astrojs/markdown-remark": "7.1.2",
         "@mdx-js/mdx": "^3.1.1",
         "acorn": "^8.16.0",
         "es-module-lexer": "^2.0.0",
@@ -90,9 +95,9 @@
       }
     },
     "node_modules/@astrojs/prism": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-4.0.1.tgz",
-      "integrity": "sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-4.0.2.tgz",
+      "integrity": "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==",
       "license": "MIT",
       "dependencies": {
         "prismjs": "^1.30.0"
@@ -2065,6 +2070,12 @@
         "node": "*"
       }
     },
+    "node_modules/@types/braces": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/braces/-/braces-3.0.5.tgz",
+      "integrity": "sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==",
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2125,6 +2136,15 @@
       "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.13.tgz",
       "integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==",
       "license": "MIT"
+    },
+    "node_modules/@types/micromatch": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/micromatch/-/micromatch-4.0.10.tgz",
+      "integrity": "sha512-5jOhFDElqr4DKTrTEbnW8DZ4Hz5LRUEmyrGpCMrD/NphYv3nUnaF08xmSLx1rGGnyEs/kFnhiw6dCgcDqMr5PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/braces": "*"
+      }
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -3068,59 +3088,6 @@
         "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta"
       }
     },
-    "node_modules/astro/node_modules/@astrojs/internal-helpers": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.0.tgz",
-      "integrity": "sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.4",
-        "@types/mdast": "^4.0.4",
-        "js-yaml": "^4.1.1",
-        "picomatch": "^4.0.4",
-        "retext-smartypants": "^6.2.0",
-        "shiki": "^4.0.2",
-        "smol-toml": "^1.6.0",
-        "unified": "^11.0.5"
-      }
-    },
-    "node_modules/astro/node_modules/@astrojs/markdown-remark": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.0.tgz",
-      "integrity": "sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==",
-      "license": "MIT",
-      "dependencies": {
-        "@astrojs/internal-helpers": "0.10.0",
-        "@astrojs/prism": "4.0.2",
-        "github-slugger": "^2.0.0",
-        "hast-util-from-html": "^2.0.3",
-        "hast-util-to-text": "^4.0.2",
-        "mdast-util-definitions": "^6.0.0",
-        "rehype-raw": "^7.0.0",
-        "rehype-stringify": "^10.0.1",
-        "remark-gfm": "^4.0.1",
-        "remark-parse": "^11.0.0",
-        "remark-rehype": "^11.1.2",
-        "remark-smartypants": "^3.0.2",
-        "unified": "^11.0.5",
-        "unist-util-remove-position": "^5.0.0",
-        "unist-util-visit": "^5.1.0",
-        "unist-util-visit-parents": "^6.0.2",
-        "vfile": "^6.0.3"
-      }
-    },
-    "node_modules/astro/node_modules/@astrojs/prism": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-4.0.2.tgz",
-      "integrity": "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==",
-      "license": "MIT",
-      "dependencies": {
-        "prismjs": "^1.30.0"
-      },
-      "engines": {
-        "node": ">=22.12.0"
-      }
-    },
     "node_modules/astro/node_modules/@img/sharp-darwin-arm64": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
@@ -3641,7 +3608,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -4507,7 +4473,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -4975,6 +4940,32 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-mdast": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-10.1.2.tgz",
+      "integrity": "sha512-FiCRI7NmOvM4y+f5w32jPRzcxDIz+PUqDwEqn1A+1q2cdp3B8Gx7aVrXORdOKjMNDQsD1ogOr896+0jJHW1EFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-phrasing": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "rehype-minify-whitespace": "^6.0.0",
+        "trim-trailing-lines": "^2.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-parse5": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
@@ -5262,7 +5253,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -6504,7 +6494,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -6518,7 +6507,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -7268,6 +7256,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/rehype-minify-whitespace": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-6.0.2.tgz",
+      "integrity": "sha512-Zk0pyQ06A3Lyxhe9vGtOtzz3Z0+qZ5+7icZ/PL/2x1SHPbKao5oB/g/rlc6BCTajqBb33JcOe71Ye1oFsuYbnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-minify-whitespace": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-parse": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
@@ -7307,6 +7309,23 @@
         "@types/estree": "^1.0.0",
         "@types/hast": "^3.0.0",
         "hast-util-to-estree": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-remark": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-remark/-/rehype-remark-10.0.1.tgz",
+      "integrity": "sha512-EmDndlb5NVwXGfUa4c9GPK+lXeItTilLhE6ADSaQuHr4JUlKw9MidzGzx4HpqZrNCt6vnHmEifXQiiA+CEnjYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "hast-util-to-mdast": "^10.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7792,6 +7811,30 @@
         "@astrojs/starlight": ">=0.38.0"
       }
     },
+    "node_modules/starlight-llms-txt": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/starlight-llms-txt/-/starlight-llms-txt-0.10.0.tgz",
+      "integrity": "sha512-LgkSjkvdACsGHkFq1ES00F0BU4lRepjJoaUmOgxBxNWx4txwpySVPtntKdAvDvlhinyN0ZBRpnAsN/sVQ1UEfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/mdx": "^5.0.4",
+        "@types/hast": "^3.0.4",
+        "@types/micromatch": "^4.0.10",
+        "github-slugger": "^2.0.0",
+        "hast-util-select": "^6.0.4",
+        "micromatch": "^4.0.8",
+        "rehype-parse": "^9.0.1",
+        "rehype-remark": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.5",
+        "unist-util-remove": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@astrojs/starlight": ">=0.38.0",
+        "astro": "^6.0.0"
+      }
+    },
     "node_modules/stream-replace-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
@@ -7932,7 +7975,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -7952,6 +7994,16 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
       "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trim-trailing-lines": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-2.1.0.tgz",
+      "integrity": "sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -8155,6 +8207,21 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-4.0.0.tgz",
+      "integrity": "sha512-b4gokeGId57UVRX/eVKej5gXqGlc9+trkORhFJpu9raqZkZhU0zm8Doi05+HaiBsMEIJowL+2WtQ5ItjsngPXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -8,17 +8,22 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "gen:sidebar": "node scripts/convert-nav.mjs"
+    "gen:sidebar": "node scripts/convert-nav.mjs",
+    "postbuild": "node scripts/check-llms-txt.mjs"
   },
   "dependencies": {
     "@astrojs/starlight": "^0.38",
     "astro": "^6",
     "marked": "^18.0.4",
     "sharp": "^0.33",
-    "starlight-image-zoom": "^0.14"
+    "starlight-image-zoom": "^0.14",
+    "starlight-llms-txt": "^0.10.0"
   },
   "devDependencies": {
     "@vercel/node": "^5.8.4",
     "js-yaml": "^4.2.0"
+  },
+  "overrides": {
+    "@astrojs/markdown-remark": "7.2.0"
   }
 }

--- a/scripts/check-llms-txt.mjs
+++ b/scripts/check-llms-txt.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+// Smoke check for the llms.txt AI layer (PRDCT-383).
+// Runs as `postbuild` (after `astro build`) and in CI. Asserts the generated
+// artifacts exist, the entrypoint lists the named sets, the small-variant
+// exclude holds, and the Snowflake description is intact. Exits non-zero on any
+// failure so a broken AI layer fails the build instead of shipping silently.
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const dist = join(process.cwd(), 'dist');
+const src = join(process.cwd(), 'src');
+
+const failures = [];
+const ok = (msg) => console.log(`  ✓ ${msg}`);
+const fail = (msg) => {
+  failures.push(msg);
+  console.error(`  ✗ ${msg}`);
+};
+
+const read = (path) => (existsSync(path) ? readFileSync(path, 'utf8') : null);
+
+// 1. The four artifacts exist and are non-empty.
+const artifacts = {
+  'llms.txt': join(dist, 'llms.txt'),
+  'llms-full.txt': join(dist, 'llms-full.txt'),
+  'llms-small.txt': join(dist, 'llms-small.txt'),
+  'Transformations set': join(dist, '_llms-txt', 'transformations.txt'),
+};
+const content = {};
+for (const [name, path] of Object.entries(artifacts)) {
+  const body = read(path);
+  content[name] = body;
+  if (body === null) fail(`${name} is missing (${path})`);
+  else if (body.trim().length === 0) fail(`${name} is empty`);
+  else ok(`${name} exists and is non-empty (${body.length} bytes)`);
+}
+
+// 2. llms.txt lists the named sets.
+const entry = content['llms.txt'] ?? '';
+for (const marker of ['llms-small.txt', 'llms-full.txt', 'transformations.txt']) {
+  if (entry.includes(marker)) ok(`llms.txt links the ${marker} set`);
+  else fail(`llms.txt does not link ${marker}`);
+}
+
+// 3. The exclude holds: the Bing Ads report-presets reference is in the full
+//    variant but stripped from the small variant.
+const MARKER = 'AccountPerformance Report Presets';
+const full = content['llms-full.txt'] ?? '';
+const small = content['llms-small.txt'] ?? '';
+if (full.includes(MARKER)) ok('report-presets page present in llms-full.txt');
+else fail('report-presets page missing from llms-full.txt (should be included)');
+if (!small.includes(MARKER)) ok('report-presets page excluded from llms-small.txt');
+else fail('report-presets page leaked into llms-small.txt (exclude broken)');
+
+// 4. The Snowflake description is intact (no garble from the em-dash edit).
+const snowflake = read(
+  join(src, 'content', 'docs', 'transformations', 'snowflake-plain', 'index.md'),
+);
+if (snowflake === null) {
+  fail('snowflake-plain/index.md is missing');
+} else {
+  const desc = (snowflake.match(/^description:\s*(.+)$/m) || [])[1] ?? '';
+  if (/query and syntax limits/.test(desc) && /Snowflake backend/.test(desc)) {
+    ok('snowflake description is intact');
+  } else {
+    fail(`snowflake description looks garbled: ${desc}`);
+  }
+}
+
+if (failures.length) {
+  console.error(`\nllms.txt smoke check FAILED (${failures.length} issue(s)).`);
+  process.exit(1);
+}
+console.log('\nllms.txt smoke check passed.');

--- a/src/content/docs/components/extractors/marketing-sales/bing-ads/report-presets-columns-and-pk/index.md
+++ b/src/content/docs/components/extractors/marketing-sales/bing-ads/report-presets-columns-and-pk/index.md
@@ -1,6 +1,7 @@
 ---
 title: Columns and primary key of report configuration presets
 slug: 'components/extractors/marketing-sales/bing-ads/report-presets-columns-and-pk'
+description: Reference of the output columns and primary keys for each Bing Ads report configuration preset in the Bing Ads data source connector.
 redirect_from:
     - /extractors/marketing-sales/bing-ads/report-presets-columns-and-pk/
 ---

--- a/src/content/docs/transformations/snowflake-plain/index.md
+++ b/src/content/docs/transformations/snowflake-plain/index.md
@@ -1,6 +1,7 @@
 ---
 title: Snowflake Transformation
 slug: 'transformations/snowflake-plain'
+description: 'Run SQL transformations on Keboola''s Snowflake backend: its advantages, query and syntax limits, and how it differs from other backends.'
 redirect_from:
   - /transformations/snowflake/
 ---


### PR DESCRIPTION
## What

Wires the **AI layer** for the docs: adds [`starlight-llms-txt`](https://delucis.github.io/starlight-llms-txt/) so the build emits `/llms.txt`, `/llms-full.txt`, `/llms-small.txt` and a per-domain **Transformations** set (`/_llms-txt/transformations.txt`) — the [llmstxt.org](https://llmstxt.org) standard. This gives external AI agents and our own Ask Kai RAG a curated, structured entrypoint to the documentation.

Config highlights (`astro.config.mjs`):
- standalone `description` of Keboola for the `llms.txt` header
- `promote` floats section indexes + the Diátaxis Transformations pilot to the top
- `exclude` trims the noisiest deep-reference page from the small variant
- a `customSets` entry so agents can pull the Transformations domain on its own

Also:
- backfilled `description` on two pages that lacked it (`snowflake-plain`, Bing Ads `report-presets-columns-and-pk`)
- added `scripts/check-llms-txt.mjs`, run as `postbuild`, asserting the four artifacts exist + are non-empty, `llms.txt` lists the sets, the `exclude` invariant holds, and the Snowflake description is intact. CI runs `npm run build`, so this fires in CI.

## Why `overrides` pins `@astrojs/markdown-remark` to `7.2.0`

Adding the plugin re-resolved the dependency tree. `astro@6.4.7` requires `@astrojs/markdown-remark@7.2.0` (which exports `unified`), but `@astrojs/starlight` depends on `^7.0.0`, so a plain install **re-hoists `7.1.2` (no `unified` export) to the top level**, shadowing the version Astro's prerender pipeline imports — the build then fails generating static routes. The `overrides` pin forces a single `7.2.0` across the tree. **Do not drop the pin** without re-checking `npm ls @astrojs/markdown-remark`.

## Status / framing

**AI layer is wired** — `llms.txt` generation, structured metadata, and a build-time smoke check are in place. Index *quality* improves as the **Diátaxis split** and **PRDCT-377** (site-wide description coverage) land. This is the plumbing, not the finish line.

## Verification

- `npm run build` clean; 254 pages built
- `postbuild` smoke check: 10/10 assertions green locally
- artifacts confirmed: `dist/llms.txt`, `dist/llms-full.txt`, `dist/llms-small.txt`, `dist/_llms-txt/transformations.txt`
- `exclude` verified: report-presets present in full, absent from small

🤖 Generated with [Claude Code](https://claude.com/claude-code)