### PR TITLE
PRDCT-373: task-oriented "Load Data from Snowflake" how-to

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -5,6 +5,12 @@ items:
   - url: /overview/
     title: Keboola Overview
 
+  - url: /how-to/
+    title: How-to Guides
+    items:
+      - url: /how-to/load-data-from-snowflake/
+        title: How do I load data from Snowflake?
+
   - url: /tutorial/
     title: Getting Started Tutorial
     items:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "gen:sidebar": "node scripts/convert-nav.mjs"
+    "gen:sidebar": "node scripts/convert-nav.mjs",
+    "new:page": "node scripts/new-page.mjs"
   },
   "dependencies": {
     "@astrojs/starlight": "^0.38",

--- a/scripts/new-page.mjs
+++ b/scripts/new-page.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * new-page.mjs — scaffold a standard, ready-to-edit docs page.
+ *
+ * Creates a page that already meets the bar (title, slug, filled-in description,
+ * task-oriented skeleton), optionally wires it into the sidebar, and prints a
+ * review checklist — so a new page is a 10-second process, not a copy-paste ritual.
+ *
+ * Usage:
+ *   npm run new:page -- --title "How do I schedule a flow?" --section "How-to Guides"
+ *   node scripts/new-page.mjs --title "…" [--slug how-to/schedule-a-flow] \
+ *        [--section "How-to Guides"] [--type how-to|concept] [--nav] [--force]
+ *
+ * --nav   also inserts the page under its section in _data/navigation.yml
+ *         (run `npm run gen:sidebar` afterwards).
+ */
+import { writeFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const DOCS = join(ROOT, 'src', 'content', 'docs');
+const NAV = join(ROOT, '_data', 'navigation.yml');
+
+const arg = (k, d = null) => {
+  const i = process.argv.indexOf(`--${k}`);
+  return i >= 0 && process.argv[i + 1] && !process.argv[i + 1].startsWith('--')
+    ? process.argv[i + 1]
+    : d;
+};
+const flag = (k) => process.argv.includes(`--${k}`);
+
+const title = arg('title');
+if (!title) {
+  console.error('✗ --title is required.  e.g. --title "How do I schedule a flow?"');
+  process.exit(1);
+}
+const type = arg('type', 'how-to');
+const slug =
+  arg('slug') ||
+  `${type === 'how-to' ? 'how-to/' : ''}` +
+    title.toLowerCase().replace(/[^\w\s-]/g, '').trim().replace(/\s+/g, '-');
+const section = arg('section');
+
+const TEMPLATES = {
+  'how-to': (t) => `${oneLine(t)} explains the goal in one sentence so search,
+the page lede, and Ask Kai have something to work with — replace this with the
+real description.
+
+Open with the reader's task and the outcome: what they want to do and what they
+will have when they're done.
+
+## Before you start
+
+- What they need (access, credentials, prerequisites).
+
+## Steps
+
+1. **First action** — do the thing and what to expect.
+2. **Second action** — keep each step a single, verifiable move.
+3. **Verify** — how the reader knows it worked.
+
+## Troubleshooting
+
+- **Symptom** — the likely cause and the fix.
+
+## Next steps
+
+- Where to go after succeeding here.
+`,
+  concept: () => `One-sentence definition of the concept — replace the description above.
+
+Explain what it is, why it matters, and when to use it. Link out to the how-to
+guides that put it into practice.
+`,
+};
+
+const buildDesc = (t) =>
+  type === 'how-to'
+    ? `Step-by-step guide: ${oneLine(t).replace(/\?$/, '').replace(/^How do I /i, '').trim()}.`
+    : `Overview of ${oneLine(t)}.`;
+
+function oneLine(t) {
+  return t.trim();
+}
+
+const filePath = join(DOCS, slug.endsWith('/') ? `${slug}index.md` : `${slug}.md`);
+if (existsSync(filePath) && !flag('force')) {
+  console.error(`✗ ${filePath} already exists. Pass --force to overwrite.`);
+  process.exit(1);
+}
+
+const page = `---
+title: ${/[:#'"]/.test(title) ? JSON.stringify(title) : title}
+slug: '${slug}'
+description: ${JSON.stringify(buildDesc(title))}
+---
+
+${(TEMPLATES[type] || TEMPLATES['how-to'])(title)}`;
+
+mkdirSync(dirname(filePath), { recursive: true });
+writeFileSync(filePath, page);
+
+// Optional: insert into navigation under the named section.
+let navNote = '';
+if (flag('nav') && section) {
+  const nav = readFileSync(NAV, 'utf8');
+  const url = `/${slug.replace(/\/?$/, '/')}`;
+  const re = new RegExp(`(title:\\s*${section}\\s*\\n\\s*items:\\n)`);
+  if (re.test(nav)) {
+    const insert = `      - url: ${url}\n        title: ${title}\n`;
+    writeFileSync(NAV, nav.replace(re, `$1${insert}`));
+    navNote = `✓ added to "${section}" in navigation.yml — run \`npm run gen:sidebar\`\n`;
+  } else {
+    navNote = `⚠ section "${section}" not found in navigation.yml — add the nav entry by hand\n`;
+  }
+}
+
+console.log(`
+✓ created ${filePath.replace(ROOT + '/', '')}
+${navNote}Checklist before you open a PR:
+  □ Replace the draft description with a real one (≤160 chars, says the outcome)
+  □ Lead with the reader's task, not the feature
+  □ Each step is a single verifiable action; no "as shown above"
+  □ Link to related pages with absolute paths (/section/page/)
+  □ npm run gen:sidebar   (if you used --nav)
+  □ npm run build && node scripts/content-lint.mjs   → clean
+`);

--- a/scripts/new-page.mjs
+++ b/scripts/new-page.mjs
@@ -90,10 +90,31 @@ if (existsSync(filePath) && !flag('force')) {
   process.exit(1);
 }
 
+// Full Phase-3 frontmatter (see src/content.config.ts and
+// scripts/templates/task-page-template.md) — a scaffolded page must pass the
+// docs-page PR checklist without the author re-inventing the field set.
+const cleanTask = oneLine(title).replace(/\?$/, '').replace(/^How do I /i, '');
+const today = new Date().toISOString().slice(0, 10);
+const fmLines = [
+  `title: ${/[:#'"]/.test(title) ? JSON.stringify(title) : title}`,
+  `slug: '${slug}'`,
+  `description: ${JSON.stringify(buildDesc(title))}`,
+  `keywords: # 3–5 phrases users would actually search for`,
+  `  - ${cleanTask.toLowerCase()}`,
+];
+if (type === 'how-to') {
+  fmLines.push(
+    `task: ${cleanTask.charAt(0).toUpperCase() + cleanTask.slice(1)}`,
+    `audience: New and existing Keboola users`,
+  );
+}
+fmLines.push(
+  `last_verified: ${today} # date the steps were last checked against the product`,
+  `related: [] # absolute slugs, e.g. /components/extractors/database/`,
+);
+
 const page = `---
-title: ${/[:#'"]/.test(title) ? JSON.stringify(title) : title}
-slug: '${slug}'
-description: ${JSON.stringify(buildDesc(title))}
+${fmLines.join('\n')}
 ---
 
 ${(TEMPLATES[type] || TEMPLATES['how-to'])(title)}`;
@@ -106,7 +127,8 @@ let navNote = '';
 if (flag('nav') && section) {
   const nav = readFileSync(NAV, 'utf8');
   const url = `/${slug.replace(/\/?$/, '/')}`;
-  const re = new RegExp(`(title:\\s*${section}\\s*\\n\\s*items:\\n)`);
+  const escaped = section.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`(title:\\s*${escaped}\\s*\\n\\s*items:\\n)`);
   if (re.test(nav)) {
     const insert = `      - url: ${url}\n        title: ${title}\n`;
     writeFileSync(NAV, nav.replace(re, `$1${insert}`));
@@ -120,6 +142,8 @@ console.log(`
 ✓ created ${filePath.replace(ROOT + '/', '')}
 ${navNote}Checklist before you open a PR:
   □ Replace the draft description with a real one (≤160 chars, says the outcome)
+  □ Fill keywords (3–5 real search phrases) and related (2–4 absolute slugs)
+  □ Verify the steps in the product, then confirm last_verified
   □ Lead with the reader's task, not the feature
   □ Each step is a single verifiable action; no "as shown above"
   □ Link to related pages with absolute paths (/section/page/)

--- a/scripts/templates/task-page-template.md
+++ b/scripts/templates/task-page-template.md
@@ -1,0 +1,86 @@
+---
+# === REQUIRED FRONTMATTER (every field earns its place for humans AND AI agents) ===
+title: How do I <do the task>?          # Phrase as the customer's question. This is the page's job.
+slug: 'how-to/<short-task-slug>'         # Stable, descriptive, task-based.
+description: <One sentence: what this page lets you accomplish and the key tool/steps.>
+                                         # Feeds on-site search, the page lede, SEO meta, AND the Ask Kai RAG index.
+                                         # Write it so it answers the title on its own.
+keywords:                                # 4–8 phrases a user or agent would actually search.
+  - <natural-language phrasing of the task>
+  - <product/feature name>
+  - <synonyms and the "wrong" words people use>
+task: <Imperative one-liner of the goal>
+audience: <e.g. New users / Admins / Developers>
+last_verified: <YYYY-MM-DD>              # When a human last confirmed the steps against the live product.
+related:                                 # Reference pages this task routes into for depth.
+  - /<path-to-reference-page>/
+---
+
+<!--
+AUTHORING RULES — delete this comment block before publishing.
+
+ONE PAGE = ONE TASK. A reader (human or agent) lands here and can finish the task
+without first having to understand how Keboola is structured internally.
+
+WRITE FOR AGENTS (this also makes it better for humans):
+  • Be literal. Name controls exactly: **Set Up Credentials First**, not "the button".
+  • Give the navigation path: (Components → Data Source Connectors → Add Component).
+  • NEVER rely on a screenshot to carry meaning. No "as shown above", "the icon on the right".
+    If a step needs a visual, describe the outcome in words instead.
+  • Every code/config block is copy-pasteable, with placeholders in CAPS (MY_WAREHOUSE).
+  • State success criteria explicitly (the "Confirm it worked" step) — agents need to know when they're done.
+  • Define or link any term the reader may not know; don't assume the Keboola taxonomy.
+  • Use the fixed heading set below so anchors are predictable and retrieval is consistent.
+  • Keep links absolute (/section/page/) so a copied-as-Markdown page still resolves.
+
+SCREENSHOTS: default to none. Add an image ONLY when it conveys something words cannot
+(e.g. a topology diagram). A screenshot of a form or a button is not that — describe it.
+-->
+
+You want to <plain statement of the goal and why someone does this>. In Keboola this is done with **<the tool/feature>**. This page takes you from <starting point> to <finished outcome>.
+
+**Time:** ~<n> minutes · **You will need:** <one-line prerequisites summary>.
+
+## Before you start
+
+Make sure you have:
+
+- <Prerequisite 1 — account/permission/access>
+- <Prerequisite 2 — information to have ready, e.g. connection details>
+- <Prerequisite 3 — anything to set up elsewhere first, with a link>
+
+## Step 1 — <first concrete action, named for its outcome>
+
+<Literal instructions. If config/code is involved, put it in a fenced block with CAPS placeholders.>
+
+## Step 2 — <next action>
+
+1. <Numbered, single-action steps.>
+2. <Name every control and the path to it.>
+3. <Click **Save** / **Run** / **Create** — use the real label.>
+
+## Step 3 — <continue until the task is done>
+
+<...>
+
+## Confirm it worked
+
+1. <How to check the result, e.g. open **Storage** and find the bucket.>
+2. <What "success" looks like — counts, a status, a visible object.>
+
+You have now <restated finished outcome>.
+
+## <Optional: the most common next step or variation>
+
+<e.g. "Load only new rows next time", "Schedule it to run automatically". One per heading, task-framed.>
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| <what the user sees> | <why> | <what to do, with a link if deeper> |
+
+## Related
+
+- [<Reference page>](/<path>/) — <what depth it adds>.
+- [<Tutorial or adjacent task>](/<path>/) — <when to go there>.

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -13,6 +13,15 @@ export const collections = {
         icon: z.string().optional(),
         section: z.string().optional(),
         beacon: z.boolean().optional(),
+        // Phase 3 authoring fields (task pages) — feed search, Ask Kai/RAG,
+        // retrieval, and freshness tracking.
+        keywords: z.array(z.string()).optional(),
+        task: z.string().optional(),
+        audience: z.string().optional(),
+        // YAML parses an unquoted `2026-06-16` as a Date, quoted as a string —
+        // accept either so authors don't have to remember to quote it.
+        last_verified: z.union([z.string(), z.date()]).optional(),
+        related: z.array(z.string()).optional(),
       }),
     }),
   }),

--- a/src/content/docs/how-to/index.md
+++ b/src/content/docs/how-to/index.md
@@ -1,0 +1,13 @@
+---
+title: How-to Guides
+slug: 'how-to'
+description: Task-oriented guides organized around what you want to get done in Keboola — start from the goal, not the feature.
+---
+
+These guides are organized around **what you want to accomplish**, not around how the product is structured. Each one takes a single real task and walks it end to end, so you can land here, follow the steps, and succeed without first learning how Keboola works under the hood.
+
+## Loading data
+
+- [How do I load data from Snowflake?](/how-to/load-data-from-snowflake/)
+
+More guides are on the way. Looking for a task that isn't here yet? Open an issue on the repo or ask in the docs channel.

--- a/src/content/docs/how-to/load-data-from-snowflake.md
+++ b/src/content/docs/how-to/load-data-from-snowflake.md
@@ -1,0 +1,115 @@
+---
+title: How do I load data from Snowflake?
+slug: 'how-to/load-data-from-snowflake'
+description: Load tables from a Snowflake database into Keboola Storage using the Snowflake data source connector, including the Snowflake permissions to grant and how to set up incremental loads.
+keywords:
+  - load data from Snowflake
+  - Snowflake extractor
+  - Snowflake data source connector
+  - import Snowflake tables
+  - Snowflake incremental fetching
+task: Load data from Snowflake into Keboola
+audience: New and existing Keboola users
+last_verified: 2026-06-16
+related:
+  - /components/extractors/database/
+  - /components/extractors/database/sqldb/
+  - /tutorial/load/database/
+---
+
+You want to bring tables from a Snowflake database into Keboola so you can transform, combine, and use that data. In Keboola this is done with the **Snowflake data source connector** (a query-based database connector). This page takes you from nothing to data landing in Keboola Storage.
+
+**Time:** ~15 minutes · **You will need:** a Keboola project and a Snowflake account with rights to grant access.
+
+## Before you start
+
+Make sure you have:
+
+- A Keboola project you can sign in to, with rights to create configurations.
+- Snowflake connection details: **account identifier** (host), **warehouse**, **database**, and **schema** you want to read from.
+- Permission in Snowflake to run `GRANT` statements (or a colleague who can). You will create a dedicated read-only user for Keboola in Step 1.
+
+If your Snowflake instance is not reachable from the public internet, you will also need to set up an [SSH tunnel](/components/extractors/database/#connecting-to-database). That is covered separately; the steps below assume a directly reachable host.
+
+## Step 1 — Create a read-only Snowflake user for Keboola
+
+Always give Keboola its own user with read-only access, rather than reusing a personal login. Run the following in Snowflake, replacing the `MY_*` placeholders with your warehouse, database, and schema names and choosing a password:
+
+```sql
+CREATE ROLE KEBOOLA_SNOWFLAKE_EXTRACTOR;
+GRANT USAGE ON WAREHOUSE MY_WAREHOUSE TO ROLE KEBOOLA_SNOWFLAKE_EXTRACTOR;
+GRANT USAGE ON DATABASE MY_DATA TO ROLE KEBOOLA_SNOWFLAKE_EXTRACTOR;
+GRANT USAGE ON SCHEMA MY_DATA.MY_SCHEMA TO ROLE KEBOOLA_SNOWFLAKE_EXTRACTOR;
+GRANT SELECT ON ALL TABLES IN SCHEMA MY_DATA.MY_SCHEMA TO ROLE KEBOOLA_SNOWFLAKE_EXTRACTOR;
+GRANT SELECT ON ALL VIEWS IN SCHEMA MY_DATA.MY_SCHEMA TO ROLE KEBOOLA_SNOWFLAKE_EXTRACTOR;
+CREATE USER KEBOOLA_SNOWFLAKE_EXTRACTOR PASSWORD = 'MY_PASSWORD' DEFAULT_ROLE = KEBOOLA_SNOWFLAKE_EXTRACTOR MUST_CHANGE_PASSWORD = FALSE TYPE = LEGACY_SERVICE;
+GRANT ROLE KEBOOLA_SNOWFLAKE_EXTRACTOR TO USER KEBOOLA_SNOWFLAKE_EXTRACTOR;
+```
+
+This grants access to the tables and views that exist **now**. Tables created later will not be readable until you re-run the two `GRANT SELECT ON ALL ... ` statements (or grant the role broader future privileges).
+
+## Step 2 — Add the Snowflake connector in Keboola
+
+1. In your Keboola project, open **Components** and choose **Add Component** (Components → Data Source Connectors).
+2. Search for **Snowflake** and select the Snowflake data source connector.
+3. Choose **Add Configuration**, give it a name that describes the source (for example, `Snowflake — Sales DB`), and confirm.
+
+You now have an empty configuration, ready for credentials.
+
+## Step 3 — Connect to your Snowflake database
+
+1. In the new configuration, click **Set Up Credentials First**.
+2. Enter the connection details for the `KEBOOLA_SNOWFLAKE_EXTRACTOR` user from Step 1: host/account, warehouse, database, schema, username, and password.
+3. Click **Test Credentials**, then **Save**.
+
+If the test fails, see [Troubleshooting](#troubleshooting) below before continuing.
+
+## Step 4 — Choose the tables to load
+
+After the credentials are saved, the connector automatically lists every table and view the user can read.
+
+1. Select the tables you want to bring into Keboola.
+2. Click **Create**.
+
+Each selected table becomes a row in the configuration. You can:
+
+- Add another table later with **New Table**.
+- Open any table to edit what it loads, or disable it so it is skipped when the whole configuration runs.
+- Change the connection later via the **Database Credentials** link.
+
+## Step 5 — Run it and confirm the data landed
+
+1. Click **Run** on the configuration.
+2. When the job finishes successfully, open **Storage** and find the bucket created for this connector.
+3. Confirm your tables are there with the expected row counts.
+
+You have now loaded data from Snowflake into Keboola.
+
+## Load only new rows next time (incremental fetching)
+
+By default each run reloads the full table. For large tables that only grow or get updated, switch on **incremental fetching** so each run reads only changed rows:
+
+1. Open the table in the configuration.
+2. Set the **ordering column** — either an always-increasing ID or a last-modified timestamp.
+3. Save and run.
+
+Keboola records the highest value it has seen in the configuration state and, on the next run, fetches only rows beyond that value. Incremental fetching suits tables where rows are added (and optionally updated) but not hard-deleted; it cannot detect `DELETE` statements. If you need to capture deletes or every change, review the [Change Data Capture options](/components/extractors/database/#change-data-capture-cdc).
+
+## Schedule it to run automatically
+
+To keep Keboola in sync, add this connector to a [Flow](/flows/) and set a schedule (for example, hourly or nightly). The connector runs in scheduled intervals (micro-batching) rather than streaming changes in real time.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| **Test Credentials** fails to connect | Wrong account/host, or host not reachable | Re-check the account identifier; if the database is private, set up an [SSH tunnel](/components/extractors/database/#connecting-to-database). |
+| Connects, but no tables are listed | The role lacks `USAGE`/`SELECT` on the schema | Re-run the `GRANT` statements from Step 1 for the correct database and schema. |
+| A new table is missing from the list | Grants only covered tables that existed at grant time | Re-run the two `GRANT SELECT ON ALL ...` statements, then refresh. |
+| "insufficient privileges" during a run | Warehouse usage not granted | Confirm `GRANT USAGE ON WAREHOUSE ... TO ROLE KEBOOLA_SNOWFLAKE_EXTRACTOR`. |
+
+## Related
+
+- [Database data source connectors](/components/extractors/database/) — overview, SSH tunnel, and CDC options.
+- [SQL database connectors — configuration reference](/components/extractors/database/sqldb/) — advanced mode and server-specific notes.
+- [Tutorial: Loading data from a database](/tutorial/load/database/) — guided walkthrough.

--- a/src/sidebar.mjs
+++ b/src/sidebar.mjs
@@ -5,6 +5,14 @@ export const sidebar = [
   { label: "Home", slug: "index" },
   { slug: "overview" },
   {
+    label: "How-to Guides",
+    collapsed: true,
+    items: [
+      { label: "Overview", slug: "how-to" },
+      { slug: "how-to/load-data-from-snowflake" },
+    ],
+  },
+  {
     label: "Getting Started Tutorial",
     collapsed: true,
     items: [


### PR DESCRIPTION
## What

Adds the first Diátaxis **how-to** page — one task start to finish with literal control names and navigation paths — plus a How-to Guides section in the sidebar.

Authoring infrastructure for task pages:
- `src/content.config.ts`: optional task-page frontmatter (`keywords`, `task`, `audience`, `last_verified`, `related`) feeding search, RAG, and freshness tracking.
- `scripts/new-page.mjs` + `scripts/templates/task-page-template.md`: scaffold new task pages; `npm run new:page`.
- `_data/navigation.yml` + regenerated `src/sidebar.mjs`.

## Scope

Child of **PRDCT-372** (Snowflake split, #988): the reference/explanation halves ship there; this is the how-to half. `npm run build` is clean (256 pages).

Linear: PRDCT-373

🤖 Generated with [Claude Code](https://claude.com/claude-code)