### PR TITLE
fix: Ask Kai source links all return 404

### DIFF
--- a/api/chat.ts
+++ b/api/chat.ts
@@ -109,6 +109,41 @@ async function askDocsQuestion(
   };
 }
 
+// ─── Source URL normalization ────────────────────────────────────────────
+
+/**
+ * The AI Service indexes docs by their GitHub repo file paths, so it returns
+ * source URLs like
+ *   https://help.keboola.com/connection-docs/src/content/docs/storage
+ * instead of the published page URL
+ *   https://help.keboola.com/storage/
+ * which 404s. Strip the repo-path prefix and normalize to the published form.
+ *
+ * Idempotent: URLs that don't carry the prefix (or live on another host such as
+ * developers.keboola.com / components.keboola.com) are returned unchanged, so
+ * this becomes a no-op once the upstream index is fixed.
+ */
+function normalizeSourceUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    if (u.hostname !== 'help.keboola.com') return url;
+
+    // Match an optional leading `/connection-docs` then `/src/content/docs`.
+    const prefix = /^\/(?:connection-docs\/)?src\/content\/docs\//;
+    if (!prefix.test(u.pathname)) return url;
+
+    let path = u.pathname.replace(prefix, '');
+    // Defensive: drop a trailing `/index` and any markdown extension.
+    path = path.replace(/\.mdx?$/i, '').replace(/\/index$/i, '');
+    // Exactly one leading + trailing slash.
+    path = '/' + path.replace(/^\/+|\/+$/g, '') + '/';
+
+    return `https://help.keboola.com${path}`;
+  } catch {
+    return url;
+  }
+}
+
 // ─── Source label helpers ────────────────────────────────────────────────
 
 /**
@@ -190,7 +225,10 @@ async function handleDocsQuestion(message: string, res: VercelResponse) {
   if (answer.source_urls.length) {
     const items = answer.source_urls
       .slice(0, 6)
-      .map((url) => ({ url, label: labelForUrl(url) }));
+      .map((raw) => {
+        const url = normalizeSourceUrl(raw);
+        return { url, label: labelForUrl(url) };
+      });
     writeSse(res, { type: 'sources', items });
   }
 


### PR DESCRIPTION
## Problem

A user reported that **every source link Kai returns 404s**. Reproduced against production:

```
Kai returns:  https://help.keboola.com/connection-docs/src/content/docs/storage   → 404
should be:    https://help.keboola.com/storage/                                    → 200
```

**Root cause:** The upstream AI Service (`POST /docs/question`) returns source URLs built from the **GitHub repo file paths** (`connection-docs/src/content/docs/<slug>`) rather than the published doc URLs. Our proxy (`api/chat.ts`) passed `metadata.sources` / `sourceUrls` through verbatim, so every `help.keboola.com` chip pointed at a non-existent path.

Confirmed identical across many queries; URLs on `developers.keboola.com` / `components.keboola.com` are already correct.

## Fix

Add an idempotent `normalizeSourceUrl()` that strips the `…/src/content/docs/` repo prefix and normalizes to `https://help.keboola.com/<slug>/`. Applied to each source before building the `sources` event, so both the URL and its label derive from the corrected value.

- No-op for URLs without the prefix, other hosts, or already-correct URLs — so it stays harmless once the upstream index is fixed.
- Defensively strips a trailing `/index` and `.md`/`.mdx` (none observed, cheap insurance).

## Verification

- ✅ Inline unit checks (production URLs, other hosts, already-correct URLs, garbage input) all pass.
- ✅ Every corrected URL returns HTTP 200 in production (`/storage/`, `/data-apps/streamlit/`, `/components/applications/custom-python/`, `/transformations/`, …).
- ✅ `npm run build` clean.
- ⏳ Final check against the live `/api/chat` endpoint once the Vercel function deploys.

## Follow-up

The real fix belongs in the AI Service knowledge base, which is storing repo file paths instead of published slugs. This proxy normalizer is a stopgap; flagging to that team so the source of truth gets corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)