### PR TITLE
fix: inline bold in step lists renders as a staircase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,10 @@ The full repo guide — stack, structure, commands, and conventions — lives in
   dev server running; kill stale ones (`pkill -f "astro dev"`) before starting.
 - **Content → edit `src/content/docs/` directly** (Markdown).
 - **CSS/UI changes go only in `src/styles/custom.css`.**
+- **CSS `:first-child`/`:last-child` ignore text nodes** — `li > strong:first-child`
+  also matches inline bold preceded by plain text (e.g. `Select **X**`). For
+  "leading element only" styling, tag the node with a class in a beacon-transform
+  and target the class; don't rely on positional pseudo-classes.
 - **Verify view-transition-sensitive CSS in a production build**
   (`astro build && astro preview`), not `npm run dev` — Vite injects `<style>`
   tags that don't survive Astro view-transition swaps.

--- a/src/integrations/beacon-transforms.mjs
+++ b/src/integrations/beacon-transforms.mjs
@@ -286,14 +286,28 @@ function boldFirstPhrase(node) {
     const firstPara = li.children?.find((c) => c.type === 'paragraph');
     if (!firstPara || !firstPara.children?.length) continue;
     const firstChild = firstPara.children[0];
+
+    // A leading authored bold (`**Title**` at the very start of the item) is a
+    // genuine step title — tag it so CSS can block it. Do NOT tag inline bold
+    // that follows text (e.g. "Select **Applications**"): that's mid-sentence
+    // emphasis, and CSS `:first-child` would otherwise mistake it for a title
+    // because it ignores the leading text node, breaking the step onto a
+    // staircase of lines.
+    if (firstChild.type === 'strong') {
+      addClass(firstChild, 'beacon-step-title');
+      continue;
+    }
     if (firstChild.type !== 'text') continue;
     const value = firstChild.value;
     const splitMatch = value.match(/^([^—:.]{1,60})([—:.])\s*(.*)$/s);
     if (!splitMatch) continue;
     const [, title, , rest] = splitMatch;
-    const newChildren = [
-      { type: 'strong', children: [{ type: 'text', value: title.trim() }] },
-    ];
+    const titleNode = {
+      type: 'strong',
+      data: { hProperties: { className: ['beacon-step-title'] } },
+      children: [{ type: 'text', value: title.trim() }],
+    };
+    const newChildren = [titleNode];
     if (rest) newChildren.push({ type: 'text', value: ` ${rest}` });
     firstPara.children.splice(0, 1, ...newChildren);
   }

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -796,7 +796,7 @@ nav.sidebar {
 .sl-markdown-content ol.beacon-steps:not(:where(.not-content *)) > li::marker {
   content: '';
 }
-.sl-markdown-content ol.beacon-steps:not(:where(.not-content *)) > li > strong:first-child {
+.sl-markdown-content ol.beacon-steps:not(:where(.not-content *)) > li > strong.beacon-step-title {
   display: block;
   font-size: 14px;
   font-weight: 600;


### PR DESCRIPTION
## Problem

On step-list pages (e.g. **data-apps/authentication/auth0**), mid-sentence bold in a numbered step breaks onto its own line, producing a staircase:

```
2. Select
   Applications
   and click Applications.
```

instead of a single inline line like the GCP OIDC page:

```
• Select APIs & Services.
```

## Root cause

The `.beacon-steps` styling uses:

```css
ol.beacon-steps > li > strong:first-child { display: block; }
```

to render a step's **leading title phrase** as a block. But CSS `:first-child` ignores leading *text* nodes, so in

```html
<li>Select <strong>Applications</strong> and click <strong>Applications</strong>.</li>
```

the inline `<strong>Applications</strong>` counts as the "first child element" and gets `display:block` → staircase.

## Fix

Tag only *genuine* leading titles with a `beacon-step-title` class in `beacon-transforms.mjs` — authored `**Title**` at the very start of an item, or the phrase `boldFirstPhrase` splits off a leading `text` node — and target that class in CSS instead of the fragile `:first-child`. Inline bold that follows text stays inline.

- `src/integrations/beacon-transforms.mjs` — tag leading titles with `beacon-step-title`
- `src/styles/custom.css` — `strong:first-child` → `strong.beacon-step-title`

## Verification (local production build)

- Auth0 OIDC steps now render inline; only the genuine full-line title (`Go to the Auth0 and log in`) stays block.
- **71** real step titles still tagged site-wide (authored + delimiter-split).
- **0** inline-bold mis-tags across all built pages.
- `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)