### PR TITLE
PRDCT-545: add docs-revamp house style + process to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,37 @@ The full repo guide — stack, structure, commands, and conventions — lives in
 - **Verify view-transition-sensitive CSS in a production build**
   (`astro build && astro preview`), not `npm run dev` — Vite injects `<style>`
   tags that don't survive Astro view-transition swaps.
-- **Screenshots:** save throwaways to `/tmp`, not the repo. `scripts/screenshot.mjs`
-  is a local-only helper (gitignored).
+- **Screenshots:** debug/dev screenshots → `/tmp`, never committed
+  (`scripts/screenshot.mjs` is a local-only helper, gitignored). Doc UI-locator
+  screenshots → `public/<section>/` (committed — they render on the page).
 - **Ask a maintainer** for product facts vs. content choices instead of guessing.
+
+## Docs authoring (house style)
+
+- **Diátaxis:** each page is ONE type — tutorial / how-to / reference / explanation.
+  Split "frankenstein" pages; don't over-split (nav suffers).
+- How-to = short, action-first, show where to click. Overview/explanation = fuller,
+  never stubs. Reference = dense; **limits at the bottom, never the top**.
+- Voice: active, short, sentence-case headings, no filler; `connector`/`component`,
+  never "plugin". Frontmatter `title` + `description` mandatory.
+- Prefer generating volatile reference from the source of truth (OpenAPI, `--help`,
+  configSchema) over hand-writing values.
+- Weave Kai in as a REPLACEMENT for low-level manual steps, not a bolt-on section;
+  prefer the Keboola Storage/Python client over raw CSV handling.
+- Doc screenshots: UI-locator only; transcribe code-in-screenshots to fenced+masked
+  blocks; drop decorative; never fabricate. Capture via Playwright against a
+  logged-in browser, verify each shot, save to `public/<section>/`.
+- Ship old→new redirects with every structural PR. Wrap wide tables (no h-scroll).
+- Decide keep/delete by supported-status + code, NOT by traffic stats.
+
+## Docs revamp process
+
+- Four stages, in order, never mixed: structure → form → accuracy → Kai-weaving.
+- Structure/form: the agent may decide. Facts and deletions: owner or code only —
+  else keep and flag `VERIFY(<owner>)` / `TODO(human-review, <owner>)`.
+- Conserve content: every removed paragraph → a new home or a logged deletion
+  (CONSERVATION-REPORT + MISSING list). Never drop silently.
+- Current guardrails: don't assert E2B as hosting; don't say Streamlit is retired;
+  don't document pricing / in-app Kai-toggle / semantic layer.
+- Stakeholder likes/dislikes + the paste-ready prompt block live in the local
+  `apps-section/` bundle (gitignored), not here.


### PR DESCRIPTION
Bakes the durable, repo-wide conventions from the Apps/Transformations revamp into agent guidance so future agents follow them (matches the pattern of keeping house style in `CLAUDE.md`).

**Adds two sections to `CLAUDE.md`:**
- **Docs authoring (house style)** — Diátaxis one-type-per-page, action-first how-tos, fuller overviews, reference with limits at the bottom, active/sentence-case voice, `connector`/`component` not "plugin", source-derived reference, Kai-as-replacement, UI-locator screenshots → `public/<section>/`, redirects with structural PRs, wrap wide tables, keep/delete by supported-status+code not traffic.
- **Docs revamp process** — four-stage pipeline (structure → form → accuracy → Kai-weaving), structure/form agent-decided vs facts/deletions owner-or-code-gated (`VERIFY`/`TODO(human-review)`), content conservation, and current guardrails (no E2B-as-hosting / Streamlit-retired / pricing / semantic-layer claims).

**Also:** rewords the screenshot rule to distinguish debug shots (`/tmp`, never committed) from doc UI-locator images (`public/<section>/`, committed) — the old wording read as a blanket ban.

Stakeholder-specific likes/dislikes and the paste-ready prompt block stay local (gitignored `apps-section/` bundle), not in the repo. One file changed (+33/-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)