### PR TITLE
PRDCT-485: cross-link the two Multi-Project Architecture pages

### DIFF
--- a/src/content/docs/catalog/multi-project/index.md
+++ b/src/content/docs/catalog/multi-project/index.md
@@ -25,6 +25,10 @@ only a *usage pattern* of the Keboola platform. The idea is to create separate p
 analyzing and writing data. The projects structure can follow the organization structure, technological structure, or
 anything else really.
 
+:::tip
+This page explains the concept with a worked example. For a guided walkthrough of *when and how* to adopt it for your organization, see the [Multi-Project Architecture Guide](/tutorial/onboarding/architecture-guide/).
+:::
+
 ## Example Scenario
 Let's say that you have an existing Keboola project that contains:
 

--- a/src/content/docs/tutorial/onboarding/architecture-guide/index.md
+++ b/src/content/docs/tutorial/onboarding/architecture-guide/index.md
@@ -10,6 +10,10 @@ Welcome to the Multi-Project Architecture Guide!
 This guide helps you effectively organize your Keboola projects, sharing successful strategies for clients of all sizes. You'll learn about various project 
 setups that meet your organizational needs and gain insights to tailor your Keboola projects for maximum efficiency and success.
 
+:::tip
+For the platform concept behind this — what multi-project architecture is and a worked example — see [Multi-Project Architecture](/catalog/multi-project/).
+:::
+
 ## Single Keboola Project 
 A **Keboola project** is the starting point for using the **Keboola Platform**, acting as a self-contained environment for managing access, data pipelines, 
 storage, and processes. It provides a structured framework for distributing tasks and access across teams, ensuring efficient data governance.


### PR DESCRIPTION
Merge-matrix item **"Multi-project ~ onboarding — keep both, cross-link."**

`catalog/multi-project` (concept deep-dive + worked Oracle/MS/GA example) and `tutorial/onboarding/architecture-guide` (onboarding guide, MPA decision questions) both cover multi-project architecture from different angles but didn't reference each other. Added a reciprocal see-also `:::tip` on each. No content moved, no pages retired.

Verified: build clean (258 pages); audit → MISSING IMAGES 0, no new broken links (3 pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)