### PR TITLE
PRDCT-546: Ask Kai sources render below the answer (not clipped)

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -1503,7 +1503,9 @@ nav.sidebar {
 }
 .ak-msg { display: flex; }
 .ak-msg-user { justify-content: flex-end; }
-.ak-msg-assistant { justify-content: flex-start; }
+/* Column so the appended .ak-sources block stacks BELOW the bubble instead of
+   becoming a side-by-side flex sibling (which pushed sources off to the right). */
+.ak-msg-assistant { flex-direction: column; align-items: flex-start; }
 .ak-bubble {
   max-width: 92%;
   padding: 10px 14px;


### PR DESCRIPTION
## Problem
In the Ask Kai drawer, the **Sources** chips render to the *right* of the answer bubble and get clipped — you have to scroll the message horizontally to see them (see report screenshot).

## Root cause
`.ak-msg` is `display: flex` (a row). `renderSources()` appends the `.ak-sources` block as a **sibling** of `.ak-bubble` inside that row, so the bubble and the sources sit side-by-side. With both at `max-width: 92%`, the row overflows and the sources are pushed off-screen. The code comment already says sources should render *under* the bubble.

## Fix
Make the assistant message stack vertically:

```css
.ak-msg-assistant { flex-direction: column; align-items: flex-start; }
```

User messages stay a row (right-aligned); assistant bubble + sources now stack, left-aligned. CSS-only, one rule.

## Verification
- `npm run build` clean; compiled CSS = `.ak-msg-assistant{flex-direction:column;align-items:flex-start}`.
- Best visual check: the PR's Vercel preview (open Ask Kai, ask anything that returns sources).

## Note (separate, upstream)
The other half of the report — a source pointing at `components.keboola.com/components/keboola.flow` ("App keboola.flow does not exist") — is an **AI Service** data problem (it maps "Flows" to a non-existent marketplace component). It's not fixable by the proxy's URL normalizer (different host) and can't be caught by a server-side HEAD check either: that page returns **HTTP 200** with an in-body error (SPA). Tracking separately for the AI Service team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)