### PR TITLE
PRDCT-347: per-page raw markdown + LLM actions dropdown

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,7 @@ import starlight from '@astrojs/starlight';
 import starlightImageZoom from 'starlight-image-zoom';
 import { sidebar } from './src/sidebar.mjs';
 import redirectFrom from './src/integrations/redirect-from.mjs';
+import pageMarkdown from './src/integrations/page-markdown.mjs';
 import beaconTransforms from './src/integrations/beacon-transforms.mjs';
 
 export default defineConfig({
@@ -16,6 +17,7 @@ export default defineConfig({
   },
   integrations: [
     redirectFrom(),
+    pageMarkdown(),
     starlight({
       title: 'Keboola User Documentation',
       favicon: '/favicon.ico',

--- a/src/components/CopyMarkdown.astro
+++ b/src/components/CopyMarkdown.astro
@@ -1,24 +1,67 @@
 ---
 /**
- * "Copy as Markdown" button — converts the current page content to markdown
- * and copies it to the clipboard. Shows a checkmark confirmation after copying.
+ * Page markdown/LLM actions — a split button next to the page title.
+ * Primary action: "Copy as Markdown" (converts the page content to markdown
+ * and copies it to the clipboard, with a checkmark confirmation).
+ * The chevron opens a menu with additional actions: View as Markdown (the
+ * page's raw `index.md` emitted by the page-markdown integration), Open in
+ * ChatGPT, and Open in Claude (each pre-filled with a "read this page" prompt).
  */
 ---
-<button
-  id="copy-md-btn"
-  class="copy-md-btn"
-  title="Copy page as Markdown"
-  aria-label="Copy page as Markdown"
->
-  <svg class="icon-copy" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-    <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
-  </svg>
-  <svg class="icon-check" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:none">
-    <polyline points="20 6 9 17 4 12"></polyline>
-  </svg>
-  <span class="copy-md-label">Copy as Markdown</span>
-</button>
+<div class="copy-md-group" id="copy-md-group">
+  <button
+    id="copy-md-btn"
+    class="copy-md-btn"
+    title="Copy page as Markdown"
+    aria-label="Copy page as Markdown"
+  >
+    <svg class="icon-copy" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+    </svg>
+    <svg class="icon-check" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:none">
+      <polyline points="20 6 9 17 4 12"></polyline>
+    </svg>
+    <span class="copy-md-label">Copy as Markdown</span>
+  </button>
+  <button
+    id="copy-md-toggle"
+    class="copy-md-toggle"
+    title="More page actions"
+    aria-label="More page actions"
+    aria-haspopup="true"
+    aria-expanded="false"
+  >
+    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <polyline points="6 9 12 15 18 9"></polyline>
+    </svg>
+  </button>
+  <div class="copy-md-menu" id="copy-md-menu" hidden>
+    <a data-md-action="view" href="#" target="_blank" rel="noopener">
+      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+        <polyline points="14 2 14 8 20 8"></polyline>
+      </svg>
+      <span>View as Markdown</span>
+    </a>
+    <a data-md-action="chatgpt" href="#" target="_blank" rel="noopener">
+      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M14 3h7v7"></path>
+        <path d="M10 14 21 3"></path>
+        <path d="M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5"></path>
+      </svg>
+      <span>Open in ChatGPT</span>
+    </a>
+    <a data-md-action="claude" href="#" target="_blank" rel="noopener">
+      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M14 3h7v7"></path>
+        <path d="M10 14 21 3"></path>
+        <path d="M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5"></path>
+      </svg>
+      <span>Open in Claude</span>
+    </a>
+  </div>
+</div>
 
 <style>
   .copy-md-btn {
@@ -175,8 +218,58 @@
     });
   }
 
+  function initActionsMenu() {
+    var toggle = document.getElementById('copy-md-toggle');
+    var menu = document.getElementById('copy-md-menu');
+    var group = document.getElementById('copy-md-group');
+    if (!toggle || !menu || !group || toggle.dataset.bound) return;
+    toggle.dataset.bound = '1';
+
+    function setOpen(open) {
+      menu.hidden = !open;
+      toggle.setAttribute('aria-expanded', String(open));
+    }
+
+    toggle.addEventListener('click', function(e) {
+      e.stopPropagation();
+      setOpen(menu.hidden);
+    });
+    document.addEventListener('click', function(e) {
+      if (!menu.hidden && !group.contains(e.target)) setOpen(false);
+    });
+    document.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape' && !menu.hidden) setOpen(false);
+    });
+    // Close after choosing an action so the menu isn't left open on return.
+    menu.addEventListener('click', function() { setOpen(false); });
+  }
+
+  // The menu links depend on the current page, so recompute them on EVERY
+  // navigation (unlike listeners, which bind once behind dataset.bound).
+  function updateMenuLinks() {
+    var menu = document.getElementById('copy-md-menu');
+    if (!menu) return;
+    // trailingSlash is 'always', so the raw markdown emitted by the
+    // page-markdown integration lives at <page>/index.md.
+    var mdUrl = location.origin + location.pathname + 'index.md';
+    var prompt = 'Read ' + mdUrl + ' so I can ask questions about it';
+
+    var view = menu.querySelector('[data-md-action="view"]');
+    var chatgpt = menu.querySelector('[data-md-action="chatgpt"]');
+    var claude = menu.querySelector('[data-md-action="claude"]');
+    if (view) view.href = location.pathname + 'index.md';
+    if (chatgpt) chatgpt.href = 'https://chatgpt.com/?hints=search&q=' + encodeURIComponent(prompt);
+    if (claude) claude.href = 'https://claude.ai/new?q=' + encodeURIComponent(prompt);
+  }
+
+  function initPageActions() {
+    initCopyBtn();
+    initActionsMenu();
+    updateMenuLinks();
+  }
+
   // Run on initial load and on Astro view transitions
-  initCopyBtn();
-  document.addEventListener('astro:page-load', initCopyBtn);
-  document.addEventListener('astro:after-swap', initCopyBtn);
+  initPageActions();
+  document.addEventListener('astro:page-load', initPageActions);
+  document.addEventListener('astro:after-swap', initPageActions);
 </script>

--- a/src/integrations/page-markdown.mjs
+++ b/src/integrations/page-markdown.mjs
@@ -1,0 +1,108 @@
+import { readFileSync, writeFileSync, mkdirSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, extname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Astro integration that emits a raw-markdown copy of every docs page.
+ *
+ * For each content file with a `slug` in its frontmatter, this writes the
+ * page's source markdown (frontmatter stripped, `# <title>` prepended) to
+ * `<outDir>/<slug>/index.md`, so every published page is also reachable as
+ * plain markdown at `https://help.keboola.com/<slug>/index.md` — for the
+ * "View as Markdown" page action and for LLMs/agents ingesting the docs.
+ *
+ * Runs in the `astro:build:done` hook, after all pages have been built.
+ * Follows the same pattern as redirect-from.mjs.
+ */
+
+/**
+ * Recursively find all .md files in a directory.
+ */
+function findMarkdownFiles(dir, files = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      findMarkdownFiles(full, files);
+    } else if (extname(full) === '.md') {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+/**
+ * Parse YAML frontmatter from a markdown file's content.
+ * Extracts only scalar fields (we need `slug` and `title`).
+ */
+function parseFrontmatter(content) {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+
+  const fm = {};
+  for (const line of match[1].split('\n')) {
+    const keyVal = line.replace(/\r$/, '').match(/^([\w][\w_-]*):\s*(.*)/);
+    if (keyVal) {
+      const val = keyVal[2].trim();
+      if (val) fm[keyVal[1]] = val.replace(/^['"]|['"]$/g, '');
+    }
+  }
+  return fm;
+}
+
+/**
+ * Strip the frontmatter block from a markdown file's content.
+ */
+function stripFrontmatter(content) {
+  return content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '');
+}
+
+export default function pageMarkdown() {
+  return {
+    name: 'page-markdown',
+    hooks: {
+      'astro:build:done': async ({ dir, logger }) => {
+        const outDir = fileURLToPath(dir);
+
+        // Resolve src/content/docs relative to this integration file.
+        const thisDir = fileURLToPath(new URL('.', import.meta.url));
+        const contentDir = join(thisDir, '..', 'content', 'docs');
+
+        if (!existsSync(contentDir)) {
+          logger.warn(`Content directory not found: ${contentDir}`);
+          return;
+        }
+
+        let written = 0;
+        let skipped = 0;
+
+        for (const file of findMarkdownFiles(contentDir)) {
+          const content = readFileSync(file, 'utf-8');
+          const fm = parseFrontmatter(content);
+
+          // Pages without a slug aren't published; the 404 page has no
+          // canonical URL worth mirroring.
+          if (fm.slug === undefined || fm.slug === '404') continue;
+
+          const mdDir = fm.slug ? join(outDir, fm.slug) : outDir;
+          const mdFile = join(mdDir, 'index.md');
+
+          // Never clobber an existing file (e.g. two sources mapping to one slug).
+          if (existsSync(mdFile)) {
+            logger.warn(`Skipping ${fm.slug || '/'} (index.md already exists)`);
+            skipped++;
+            continue;
+          }
+
+          const body = stripFrontmatter(content).trim();
+          const md = (fm.title ? `# ${fm.title}\n\n` : '') + body + '\n';
+
+          mkdirSync(mdDir, { recursive: true });
+          writeFileSync(mdFile, md);
+          written++;
+        }
+
+        logger.info(`Emitted ${written} raw-markdown pages (${skipped} skipped)`);
+      },
+    },
+  };
+}

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -615,6 +615,62 @@ nav.sidebar {
   border-color: var(--border-2);
 }
 
+/* Page actions split-button: [Copy as Markdown][▾] + dropdown menu */
+.copy-md-group {
+  position: relative;
+  display: inline-flex;
+  align-items: stretch;
+}
+/* Specificity note: these must beat `.page-title-row > :last-child button`
+   above (0-2-1), hence the class-based 0-3-0 selectors. */
+.page-title-row .copy-md-group .copy-md-btn {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+.page-title-row .copy-md-group .copy-md-toggle {
+  display: inline-flex;
+  align-items: center;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-left: 0;
+  padding: 6px 7px;
+  cursor: pointer;
+}
+.copy-md-group .copy-md-toggle[aria-expanded='true'] {
+  color: var(--fg-1);
+  background: var(--bg-2);
+}
+.copy-md-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 20;
+  min-width: 190px;
+  padding: 4px;
+  background: var(--bg-1);
+  border: 1px solid var(--border-1);
+  border-radius: 8px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08);
+}
+.copy-md-menu a {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  border-radius: 6px;
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--fg-2);
+  text-decoration: none;
+  white-space: nowrap;
+}
+.copy-md-menu a:hover {
+  background: var(--bg-2);
+  color: var(--fg-1);
+}
+.copy-md-menu a svg { flex-shrink: 0; opacity: 0.7; }
+.copy-md-menu a:hover svg { opacity: 1; }
+
 /* ───────── Markdown content ───────── */
 .sl-markdown-content {
   font-size: 15px;


### PR DESCRIPTION
Closes PRDCT-347.

## What this adds

**1. Every docs page is now also published as raw markdown** at `<page>/index.md` (e.g. `help.keboola.com/storage/index.md`) — new `src/integrations/page-markdown.mjs` (modeled on `redirect-from.mjs`, `astro:build:done`): strips frontmatter, prepends `# <title>`, skips the 404 page, never clobbers existing files. 257 pages emitted.

**2. The "Copy as Markdown" button becomes a split-button** with a chevron menu:
- **View as Markdown** → opens `<page>/index.md`
- **Open in ChatGPT** → `chatgpt.com/?hints=search&q=<"Read <md url> so I can ask questions about it">`
- **Open in Claude** → `claude.ai/new?q=<same prompt>`

Links recompute on every `astro:page-load`/`astro:after-swap` (view-transition-safe); listeners bind once behind the existing `dataset.bound` guard. Menu items are `<a>` elements so the structural `.page-title-row > :last-child button` rule doesn't restyle them; new styles are in `custom.css` only (selectors at 0-3-0 specificity to beat that structural rule — see inline comment).

## Verification (local production build)
- Build clean; `[page-markdown] Emitted 257 raw-markdown pages (0 skipped)`.
- `dist/storage/index.md` starts with `# Storage`, no frontmatter leak; homepage `dist/index.md` OK; nested slugs OK; no `dist/404/index.md`.
- Exactly one group/menu per page; copy button regression-checked (same `initCopyBtn` path).
- `astro preview`: `GET /storage/index.md` → **200 `text/markdown`**; page HTML still 200.
- `node scripts/audit-phase2.mjs`: 111 issues, all pre-existing (Jekyll link smells etc.), zero related to this change.

## Notes
- In `npm run dev` the `index.md` files don't exist (emitted at build time, like Pagefind) — View as Markdown 404s in dev only.
- Production content-type depends on the S3 sync mime mapping for `.md`; if it serves as octet-stream we may want `--content-type text/markdown` for `*.md` in the deploy step (follow-up if needed).
- Groundwork for the on-hold llms.txt work (PRDCT-383).

🤖 Generated with [Claude Code](https://claude.com/claude-code)