### PR TITLE
PRDCT-487: Tutorial & onboarding rework — descriptions + legacy-UI flags

### DIFF
--- a/src/content/docs/tutorial/ad-hoc/index.md
+++ b/src/content/docs/tutorial/ad-hoc/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Part 5: Ad-Hoc Data Analysis"
 slug: 'tutorial/ad-hoc'
+description: 'Part 5 of the tutorial — pull public data with the BigQuery connector and explore it ad hoc with Python, pandas, and Matplotlib in a Jupyter workspace.'
 ---
 
 After you have loaded your tables, either [manually](/tutorial/load/) or
@@ -147,6 +148,7 @@ Once the job is finished, click on the names of the tables to inspect their cont
 :::caution
 **Important:** The following part of the tutorial will be updated soon. Please be aware that sandboxes now exist only in their legacy form and have been replaced by workspaces.
 :::
+<!-- TODO(human-review): rewrite this "Exploring Data" walkthrough on the current Workspaces UI and recapture the screenshots (they show the retired "New Sandbox" flow). -->
 
 To explore the data, go to [**Workspaces**](/workspace/).
 Provided for each user and project automatically, it is an isolated environment in which you can experiment without

--- a/src/content/docs/tutorial/automate/index.md
+++ b/src/content/docs/tutorial/automate/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Part 4: Flow Automation"
 slug: 'tutorial/automate'
+description: 'Part 4 of the tutorial — orchestrate the load, transform, and write steps into a flow and schedule it to run automatically every day.'
 ---
 
 So far, you have learned to use Keboola to
@@ -16,7 +17,12 @@ This is where our flows come in:
 - Specify what tasks should be executed in what order (orchestrate tasks) and
 - Configure the automatic execution (schedule flow tasks).
 
-1. Navigate to the **Flows** section of Keboola.
+:::caution
+The screenshots below show the **Legacy Flow Builder**. New projects default to [Conditional Flows](/flows/), which offer conditional logic, retries, and more — the concepts here (steps, parallel tasks, schedules, notifications) carry over. To build this pipeline in the Conditional Flows builder, see [Conditional Flows](/flows/).
+:::
+<!-- TODO(human-review): re-record this walkthrough (steps + screenshots) on the Conditional Flows builder; the current one uses the Legacy builder UI. -->
+
+1. Navigate to the **Conditional Flows** section of Keboola.
 
 ![Go to Flows](/tutorial/automate/automate1.png)
 

--- a/src/content/docs/tutorial/branches/files-in-branch.md
+++ b/src/content/docs/tutorial/branches/files-in-branch.md
@@ -1,6 +1,7 @@
 ---
 title: Working with Files in Branch
 slug: 'tutorial/branches/files-in-branch'
+description: 'Learn how files behave in development branches by running the file-manipulating configurations in a branch.'
 ---
 
 

--- a/src/content/docs/tutorial/branches/index.md
+++ b/src/content/docs/tutorial/branches/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Part 6: Development Branches"
 slug: 'tutorial/branches'
+description: 'Part 6 of the tutorial — use development branches to change configurations safely without touching production pipelines.'
 ---
 
 

--- a/src/content/docs/tutorial/branches/merge-to-production.md
+++ b/src/content/docs/tutorial/branches/merge-to-production.md
@@ -1,6 +1,7 @@
 ---
 title: Merge to Production
 slug: 'tutorial/branches/merge-to-production'
+description: 'Merge a reviewed development branch back to production and clean up after the merge.'
 ---
 
 

--- a/src/content/docs/tutorial/branches/prepare-files.md
+++ b/src/content/docs/tutorial/branches/prepare-files.md
@@ -1,6 +1,7 @@
 ---
 title: Prepare File Manipulating Configurations
 slug: 'tutorial/branches/prepare-files'
+description: 'Set up the production file-manipulating configurations used in the development-branches tutorial.'
 ---
 
 

--- a/src/content/docs/tutorial/branches/prepare-tables.md
+++ b/src/content/docs/tutorial/branches/prepare-tables.md
@@ -1,6 +1,7 @@
 ---
 title: Prepare Table-Manipulating Configurations
 slug: 'tutorial/branches/prepare-tables'
+description: 'Set up the production table-manipulating configurations used throughout the development-branches tutorial.'
 ---
 
 

--- a/src/content/docs/tutorial/branches/project-diff.md
+++ b/src/content/docs/tutorial/branches/project-diff.md
@@ -1,6 +1,7 @@
 ---
 title: Project Diff
 slug: 'tutorial/branches/project-diff'
+description: 'Review changes between your development branch and production with the project diff before merging.'
 ---
 
 

--- a/src/content/docs/tutorial/branches/tables-in-branch.md
+++ b/src/content/docs/tutorial/branches/tables-in-branch.md
@@ -1,6 +1,7 @@
 ---
 title: Working with Tables in Branch
 slug: 'tutorial/branches/tables-in-branch'
+description: 'Run configurations inside a development branch and learn how Storage tables behave in branches.'
 ---
 
 

--- a/src/content/docs/tutorial/index.md
+++ b/src/content/docs/tutorial/index.md
@@ -3,6 +3,7 @@ title: Keboola Getting Started Tutorial
 slug: 'tutorial'
 redirect_from:
   - /getting-started/
+description: 'A hands-on tour of Keboola — load data, transform it with SQL, write it to a destination, automate the pipeline with a flow, and explore ad-hoc analysis.'
 ---
 
 Discover how to leverage the Keboola platform to effortlessly extract data from various sources,  transform it, and securely store it within the Keboola platform. 

--- a/src/content/docs/tutorial/load/database.md
+++ b/src/content/docs/tutorial/load/database.md
@@ -1,6 +1,7 @@
 ---
 title: Loading Data from Database
 slug: 'tutorial/load/database'
+description: 'Load data from an external Snowflake database with a database data source connector — the procedure is the same for all database sources.'
 ---
 
 So far, you have learned to load data into Keboola [manually](/tutorial/load/) and

--- a/src/content/docs/tutorial/load/googlesheets.md
+++ b/src/content/docs/tutorial/load/googlesheets.md
@@ -1,6 +1,7 @@
 ---
 title: Loading Data from Google Sheets
 slug: 'tutorial/load/googlesheets'
+description: 'Load a shared Google spreadsheet into Storage with the Google Sheets data source connector.'
 ---
 
 In the [previous step](/tutorial/load/), you learned how to quickly load data into Keboola using [manual import](/tutorial/load/).

--- a/src/content/docs/tutorial/load/manual.md
+++ b/src/content/docs/tutorial/load/manual.md
@@ -1,6 +1,7 @@
 ---
 title: "Part 1: Loading Data"
 slug: 'tutorial/load'
+description: 'Part 1 of the tutorial — load CSV files into Storage manually, the quickest way to get data in during a proof of concept.'
 ---
 
 

--- a/src/content/docs/tutorial/manipulate/index.md
+++ b/src/content/docs/tutorial/manipulate/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Part 2: Data Manipulation"
 slug: 'tutorial/manipulate'
+description: 'Part 2 of the tutorial — build a SQL transformation that denormalizes the loaded tables, with input and output mappings explained step by step.'
 ---
 
 At this juncture, you're acquainted with the swift process of loading data into Keboola, resulting in four new tables in your Storage: 

--- a/src/content/docs/tutorial/manipulate/workspace.md
+++ b/src/content/docs/tutorial/manipulate/workspace.md
@@ -1,6 +1,7 @@
 ---
 title: Using a Workspace
 slug: 'tutorial/manipulate/workspace'
+description: 'Develop and test your transformation SQL interactively in a workspace before saving it to the transformation.'
 ---
 
 An integral aspect of creating a transformation is the development of the script itself. 

--- a/src/content/docs/tutorial/onboarding/architecture-guide/bdm-guide/index.md
+++ b/src/content/docs/tutorial/onboarding/architecture-guide/bdm-guide/index.md
@@ -1,6 +1,7 @@
 ---
 title: Business Data Model Guide
 slug: 'tutorial/onboarding/architecture-guide/bdm-guide'
+description: 'Design a Business Data Model — a shared, business-oriented view of your data that guides how projects and pipelines are structured.'
 ---
 
 

--- a/src/content/docs/tutorial/onboarding/architecture-guide/index.md
+++ b/src/content/docs/tutorial/onboarding/architecture-guide/index.md
@@ -1,6 +1,7 @@
 ---
 title: Multi-Project Architecture Guide
 slug: 'tutorial/onboarding/architecture-guide'
+description: 'How to organize Keboola projects — single project, multi-project architectures, and proven setups for organizations of different sizes.'
 ---
 
 

--- a/src/content/docs/tutorial/onboarding/cheat-sheet/index.md
+++ b/src/content/docs/tutorial/onboarding/cheat-sheet/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Cheat Sheet: Best Practices"
 slug: 'tutorial/onboarding/cheat-sheet'
+description: 'Best practices for everyday Keboola work — credentials, incremental loads, transformations, flows, error handling, and development branches.'
 ---
 
 How you use Keboola can differ significantly. From setting up automated data pipelines with Flows to managing components such as data sources, destinations, 

--- a/src/content/docs/tutorial/onboarding/governance-guide/index.md
+++ b/src/content/docs/tutorial/onboarding/governance-guide/index.md
@@ -1,6 +1,7 @@
 ---
 title: Keboola Governance Guide
 slug: 'tutorial/onboarding/governance-guide'
+description: 'Governance practices for Keboola — access management, security, monitoring, and operational responsibilities across your projects.'
 ---
 
 Welcome to the Keboola Governance Guide! Here, we cover everything you need to know about managing and monitoring your use of our platform, 

--- a/src/content/docs/tutorial/onboarding/index.md
+++ b/src/content/docs/tutorial/onboarding/index.md
@@ -1,6 +1,7 @@
 ---
 title: Keboola Platform Onboarding
 slug: 'tutorial/onboarding'
+description: 'Start here after your proof of concept — a guided path through architecture planning, governance, usage documentation, and best practices.'
 ---
 
 

--- a/src/content/docs/tutorial/onboarding/usage-blueprint/index.md
+++ b/src/content/docs/tutorial/onboarding/usage-blueprint/index.md
@@ -1,6 +1,7 @@
 ---
 title: Keboola Platform Usage Blueprint
 slug: 'tutorial/onboarding/usage-blueprint'
+description: 'A customizable template for documenting how your organization uses Keboola — naming conventions, responsibilities, and operating rules.'
 ---
 
 > Welcome to your personalized Keboola Platform Usage Blueprint Document! 

--- a/src/content/docs/tutorial/write/index.md
+++ b/src/content/docs/tutorial/write/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Part 3: Writing Data"
 slug: 'tutorial/write'
+description: 'Part 3 of the tutorial — write the transformed table from Storage to Google Sheets with a data destination connector (reverse ETL).'
 ---
 
 


### PR DESCRIPTION
## Tutorial/onboarding section under the unified section-at-a-time method

Covers all 22 pages of `/tutorial/` (getting-started parts 1–6, branches sub-tutorial, onboarding guides).

### What changed
- **Every page now has `description` frontmatter** (previously zero of 22) — feeds search, RAG, and meta tags.
- **`tutorial/automate` (Part 4):** the walkthrough screenshots show the **Legacy Flow Builder**. Added a `:::caution` pointing readers to [Conditional Flows](/flows/), fixed the nav-label step to **Conditional Flows** (label verified live in-product), and flagged the walkthrough for re-recording on the conditional builder.
- **`tutorial/ad-hoc` (Part 5):** the "Exploring Data" part still teaches the retired **"New Sandbox"** flow (the page's own caution admits it). Flagged for a rewrite on the current Workspaces UI with fresh screenshots.

### Deliberately NOT done here
- **Onboarding guides placement** (architecture/BDM/governance/usage-blueprint/cheat-sheet are explanations living under `/tutorial/`) — moving them needs a nav/redirect decision and would conflict with #1005 (multi-project cross-links) currently in flight. Proposal: revisit after #1005 merges.
- Re-shooting the legacy walkthrough screenshots — needs building the tutorial pipeline in the Conditional builder; tracked in the Linear accuracy issue.

### Verification
- `npm run build` clean (258 pages).
- `node scripts/audit-phase2.mjs`: MISSING IMAGES 0; broken internal links = 3 pre-existing on main (unrelated to this branch).

**Draft — do not merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)