### PR TITLE
docs(catalog): cross-link multi-project architecture pages

### DIFF
--- a/src/content/docs/catalog/multi-project/index.md
+++ b/src/content/docs/catalog/multi-project/index.md
@@ -25,6 +25,10 @@ only a *usage pattern* of the Keboola platform. The idea is to create separate p
 analyzing and writing data. The projects structure can follow the organization structure, technological structure, or
 anything else really.
 
+:::tip
+For a strategic view of multi-project architecture -- when to adopt it, its key benefits, and the vertical, horizontal, and hybrid design strategies -- see the [**Multi-Project Architecture Guide**](/tutorial/onboarding/architecture-guide/).
+:::
+
 ## Example Scenario
 Let's say that you have an existing Keboola project that contains:
 

--- a/src/content/docs/tutorial/onboarding/architecture-guide/index.md
+++ b/src/content/docs/tutorial/onboarding/architecture-guide/index.md
@@ -39,6 +39,10 @@ and democratization, by maintaining integrated yet isolated environments to avoi
 ## Multi-Project Architecture (MPA)
 MPA is a design strategy that divides data processing tasks among multiple function-specific Keboola projects. It transforms a single-project focus on Extract, Transform, and Load (ETL) processes into a structured data platform, enhancing organizational data management. This approach clarifies the role, simplifies access control, and supports tailored data usage and governance.
 
+:::tip
+See [**Multi-Project Architecture**](/catalog/multi-project/) for a concrete, worked example of splitting a single project (Oracle, SQL Server, and Google Analytics sources) into function-specific projects, and how it maps to [Data Catalog](/catalog/) sharing.
+:::
+
 These are the key benefits of MPA:
 
 1. **Defined Roles and Access:** Facilitates role-specific access and responsibilities, ideal for diverse organizational needs.


### PR DESCRIPTION
## What

Resolves the **"multi-project ~ onboarding"** consolidation from the dev+help merge matrix — the decision there was **keep both, cross-link** (smallest, safest item).

Adds mutual `:::tip` links between the two pages that overlap on multi-project architecture:

- `/catalog/multi-project/` → links to the strategic guide (when to adopt, benefits, vertical/horizontal/hybrid design).
- `/tutorial/onboarding/architecture-guide/` → links to the concrete worked example (Oracle/SQL Server/GA split) and how it maps to Data Catalog sharing.

No content duplicated, rewritten, or deleted — this is purely a discoverability cross-link. Diátaxis re-cut of these pages stays for a later reconcile pass.

## Verification

- `npm run build` — clean, 254 pages, 0 errors.
- `node scripts/audit-phase2.mjs` — 0 new broken links / missing images from this change (the 3 broken links it reports are pre-existing and unrelated).

## Context

First unblocked step of the larger help + developers docs unification. Part of the "in-repo consolidations doable now" set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)