### PR TITLE
PRDCT-544: fold dev SSH-tunnel how-to into /components/extractors/database/

### DIFF
--- a/src/content/docs/components/extractors/database/index.md
+++ b/src/content/docs/components/extractors/database/index.md
@@ -3,6 +3,7 @@ title: Database Data Source Connectors
 slug: 'components/extractors/database'
 redirect_from:
   - /extractors/database/
+  - /integrate/database/
 
 ---
 
@@ -69,8 +70,80 @@ consists of an encrypted connection created through an SSH protocol connection. 
 your database server located in your private network that you do not want to be accessed directly from the Internet. The
 SSH connection is encrypted and uses a public-private key pair for user authorization.
 
-Find detailed instructions for setting up an SSH tunnel in the [developer documentation](https://developers.keboola.com/integrate/database/).
-While setting up an SSH tunnel requires some work, it is the most reliable and secure option for connecting to your database server.
+Setting up an SSH tunnel requires some work, but it is the most reliable and secure option for connecting to your database server.
+
+### Setting Up an SSH Tunnel
+
+Before using an SSH tunnel with one of our database connectors, set up an *SSH proxy server* to act as a gateway
+to the private network where your database server resides. The connector then connects to this *SSH proxy server*
+and through it to the database server.
+
+#### 1. Set Up an SSH Proxy Server
+
+Here is a very basic example [Dockerfile](https://docs.docker.com/engine/reference/builder/). All it does is run
+an `sshd` daemon and expose port 22. You can, of course, set this up on your system in a similar way without using
+Docker.
+
+```dockerfile
+FROM ubuntu:14.04
+
+RUN apt-get update
+
+RUN apt-get install -y openssh-server
+RUN mkdir /var/run/sshd
+
+RUN echo 'root:root' |chpasswd
+
+RUN sed -ri 's/^PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+RUN sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
+
+EXPOSE 22
+
+CMD    ["/usr/sbin/sshd", "-D"]
+```
+
+This server should be in the same private network where your database server resides, and it must be publicly
+accessible from the internet via SSH. The default port for SSH is 22, but you can choose a different one.
+
+For more information about setting up SSH on your server, see:
+
+- [OpenSSH configuration](https://help.ubuntu.com/community/SSH/OpenSSH/Configuring)
+- [Dockerized SSH service](https://docs.docker.com/engine/examples/running_ssh_service/)
+
+#### 2. Generate an SSH Key Pair
+
+Set up or edit your database connector in Keboola. Go to **Database Credentials** and check **Enable SSH Tunnel**.
+Generate an SSH key pair and copy the public key to your *SSH proxy server*. Paste it into the *public.key* file
+and then append it to the `authorized_keys` file:
+
+```bash
+mkdir ~/.ssh
+cat public.key >> ~/.ssh/authorized_keys
+```
+
+#### 3. Set Up the Database Connector
+
+- **Host Name** – address of the DB server in your private network
+- **Port** – port number of the DB server
+- **Username** – DB username
+- **Password** – DB password
+- **Database** – DB name
+- **Enable SSH Tunnel** – check to enable
+- **SSH host** – public address of your *SSH proxy server*
+- **SSH user** – user on your *SSH proxy server* with the generated public key
+- **SSH port** – SSH port; the default is 22
+
+Run **Test Credentials** to check that everything is working. Different DB connectors may have different fields,
+but the principle remains the same.
+
+#### Local Tunnel
+
+You can also use your database server itself as the *SSH proxy server* and configure your database to accept
+connections only from localhost. In this case, set the **Host Name** to `127.0.0.1`.
+
+:::caution
+Do **not** use the word `localhost` — our connectors have a problem with it. Use `127.0.0.1` instead.
+:::
 
 ## Change Data Capture (CDC)
 

--- a/src/content/docs/components/extractors/database/mysql/index.md
+++ b/src/content/docs/components/extractors/database/mysql/index.md
@@ -511,7 +511,7 @@ set @@global.binlog_row_value_options="" ;
 #### SSH tunnel
 
 You may opt to use an SSH Tunnel to secure your connection. Find detailed instructions for setting up an SSH tunnel in
-the [developer documentation](https://developers.keboola.com/integrate/database/). While setting up an SSH tunnel requires some work, it is the most reliable and secure
+the [database connectors overview](/components/extractors/database/#setting-up-an-ssh-tunnel). While setting up an SSH tunnel requires some work, it is the most reliable and secure
 option for connecting to your database server.
 
 ### Data Source

--- a/src/content/docs/components/extractors/database/postgresql/index.md
+++ b/src/content/docs/components/extractors/database/postgresql/index.md
@@ -568,7 +568,7 @@ ALTER TABLE __<table_name>__ OWNER TO REPLICATION_GROUP;
 
 #### SSH tunnel
 
-You may opt to use an SSH Tunnel to secure your connection. The [developer documentation](https://developers.keboola.com/integrate/database/ provides detailed instructions for setting up an SSH tunnel.
+You may opt to use an SSH Tunnel to secure your connection. The [database connectors overview](/components/extractors/database/#setting-up-an-ssh-tunnel) provides detailed instructions for setting up an SSH tunnel.
 While setting up an SSH tunnel requires some work, it is the most reliable and secure option for connecting to your database server.
 
 ### Data Source


### PR DESCRIPTION
## What

Cross-site consolidation **DB SSH tunnel** from the dev+help merge matrix — folds the dev-side setup how-to into the canonical help home so the topic lives on **one** page.

`/components/extractors/database/` already carried the SSH-tunnel **concept** (what/why + the schema image) but punted the **how-to** to `developers.keboola.com/integrate/database/`. This brings that how-to in as a proper Diátaxis how-to subsection and retires the dev page.

- **Fold** → new `### Setting Up an SSH Tunnel` section: SSH proxy setup (Dockerfile), key-pair generation, connector fields, local tunnel — replacing the outbound "see the developer documentation" pointer.
- **301** → `redirect_from: /integrate/database/` on the canonical page (`redirect-from` integration; generated page verified → `/components/extractors/database/`).
- **Rewire** → flip the SSH links in `mysql/` and `postgresql/` to the internal anchor `#setting-up-an-ssh-tunnel` (also fixes a broken markdown link in `postgresql/`).
- **Conserve-then-delete** → all dev prose rehomed; nothing dropped.

## VERIFY(owner)

Faithful fold of the published dev doc; a couple of specifics could use an owner/live-verify pass (happy to file a Linear accuracy issue like the PRDCT-47x handoffs if wanted):

- The example `Dockerfile` uses `ubuntu:14.04` (carried verbatim from the dev doc) — likely worth modernizing.
- UI labels (**Database Credentials**, **Enable SSH Tunnel**, **Test Credentials**) and the `localhost` quirk should be confirmed against the current connector UI.

## Out of scope

- The full Diátaxis re-cut of the `extractors/database` section (PRDCT-342) — this is just the targeted cross-site fold.
- Domain-level `developers.keboola.com/integrate/database/` → help 301 (out-of-repo/ops layer).

## Verification

- `npm run build` — clean; `[redirect-from] Generated 159 redirect pages (0 skipped)`; the `/integrate/database/` redirect resolves to `/components/extractors/database/` and the `#setting-up-an-ssh-tunnel` anchor renders.
- `node scripts/audit-phase2.mjs` — no new issues in the edited pages; `/integrate/database` no longer flagged as an outbound dev seam.

## Context

Second phase of the help + developers unification per the playbook: the dev-repo blocker for cross-site merges is now cleared (dev docs fetchable), so this is the first of the remaining dev→help folds. Follows the "how one merge runs" mechanic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
