### PR TITLE
docs(ai): link machine-readable API index for agentic usage

### DIFF
--- a/src/content/docs/ai/index.md
+++ b/src/content/docs/ai/index.md
@@ -27,6 +27,11 @@ A plugin marketplace for AI coding assistants that provides specialized agents, 
 Model Context Protocol server integration for seamless communication between AI agents and your data infrastructure on Keboola.
 [Learn more about MCP Server →](/ai/mcp-server/)
 
+### Machine-Readable API Index
+
+Every Keboola stack publishes a machine-readable index of its APIs at `https://api.<stack>/apis.json` (for example, [`https://api.keboola.com/apis.json`](https://api.keboola.com/apis.json)). The index lists each service with its base `apiUrl` and a link to its OpenAPI specification (`openApiSpecUrl`) — a convenient overview for agentic usage: AI agents, MCP servers, and other tooling that discovers Keboola's APIs programmatically.
+[View the API index →](https://api.keboola.com/apis.json)
+
 ### AI Component Suggestions
 
 Allows users to get AI suggestions when searching for a component. To activate the feature, go to Project Settings → Features → AI Component Suggestions.


### PR DESCRIPTION
## What

Adds a **Machine-Readable API Index** section to the AI Features page (`/ai/`), pointing tooling at the per-stack `apis.json` index published by [keboola/api-service#101](https://github.com/keboola/api-service/pull/101).

The index lives at `https://api.<stack>/apis.json` (e.g. `https://api.keboola.com/apis.json`) and lists each service with its base `apiUrl` and a link to its OpenAPI spec (`openApiSpecUrl`) — a convenient overview for AI agents, MCP servers, and other tooling.

The endpoint is live in production (`https://api.keboola.com/apis.json` → 200).

Companion changes: `developers-docs` (`/overview/api/`) and `api-service` (portal UI banner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
