### PR TITLE
fix: Darken inline code text for readable contrast

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -810,7 +810,7 @@ nav.sidebar {
 /* Inline code — Keboola blue-tinted */
 .sl-markdown-content :not(pre) > code:not(:where(.not-content *)) {
   background: var(--kbc-blue-100);
-  color: var(--kbc-blue-600);
+  color: var(--kbc-blue-800);
   padding: 1.5px 6px;
   border-radius: 4px;
   font-family: var(--font-mono);


### PR DESCRIPTION
## What

Inline `code` in the docs rendered as **blue-600 text on a blue-100 background** — a bright, low-contrast pairing (~3.4:1, below WCAG AA 4.5:1). This darkens the text to **blue-800** (~6.8:1, passes AA) while keeping the Keboola blue-tinted chip look.

Single-line change in `src/styles/custom.css`:

```diff
 .sl-markdown-content :not(pre) > code:not(:where(.not-content *)) {
   background: var(--kbc-blue-100);
-  color: var(--kbc-blue-600);
+  color: var(--kbc-blue-800);
```

## Why

The mid-blue text on the bright light-blue background was hard to read. `--kbc-blue-800` (`#064a8f`) on `--kbc-blue-100` (`#e0f0ff`) clears WCAG AA with headroom and still reads as brand blue.

## Scope

- Light theme only. The dark-theme inline-code rule (`rgba(31,143,255,.18)` bg + `blue-200` text) already has adequate contrast and is untouched.
- Code **blocks** (Shiki/Expressive Code) are unaffected.

## Verification

Rendered the exact resolved token colors against representative inline-code markup — before (washed out) vs after (crisp, dark blue). Contrast confirmed by luminance calc: 3.4:1 → 6.8:1.