### PR TITLE
docs(flows): document condition subjects - Any Task in the Flow + Continue on Failure (AJDA-3059, AJDA-3065)

### DIFF
--- a/src/content/docs/flows/flow-migration-guide/continue-on-failure.md
+++ b/src/content/docs/flows/flow-migration-guide/continue-on-failure.md
@@ -2,20 +2,30 @@
 title: Continue on Failure in Conditional Flows
 slug: 'flows/flow-migration-guide/continue-on-failure'
 description: >-
-  Conditional Flows have no Continue on Failure toggle, so the Legacy Flow
-  "continue on failure + warning notification" behavior is not migrated
+  Conditional Flows have no per-task Continue on Failure toggle, so the Legacy
+  Flow "continue on failure + warning notification" behavior is not migrated
   automatically. Learn how to reproduce it using conditions.
 ---
 
 When you migrate a [Legacy Flow](/flows/flows-legacy/) to a [Conditional Flow](/flows/) using the [Migration Guide](/flows/flow-migration-guide/), the **Continue on Failure** behavior does not carry over automatically. This page explains why and shows how to reproduce it with conditions.
 
 :::caution[Known issue]
-Conditional Flows have no **Continue on Failure** toggle. In Legacy Flows, enabling **Continue on Failure** on a task made the task finish with a **warning** status instead of failing the whole Flow, and could send a warning notification. Because Conditional Flows have no **Continue on Failure** toggle, this behavior is not migrated automatically — you have to rebuild it manually using [conditions](/flows/#conditions).
+In Legacy Flows, enabling **Continue on Failure** on a task made the task finish with a **warning** status instead of failing the whole Flow, and could send a warning notification. Conditional Flows have no per-task toggle — the behavior is expressed with [conditions](/flows/#conditions) — and it is not migrated automatically, so you have to rebuild it manually.
 :::
 
-## Workaround: reproduce continue-on-failure with conditions
+## Recommended: the Continue on Failure condition subject
 
-In Conditional Flows, you recreate this behavior with a condition that branches on a task's job status. The example below starts from a first phase named **Extract Data** that contains two tasks: a GitHub extractor (**My GitHub**) and a Google Sheets extractor (**Vouchers and Global Bars**).
+Add a condition to the phase and pick **Continue on Failure** as its [subject](/flows/#4-continue-on-failure) — the phase, then **Continue on Failure** — and select the tasks that are allowed to fail. Every other task in the phase must succeed for the branch to be taken.
+
+This is the closest equivalent of the Legacy Flow toggle and the option to reach for first. Use the branching described below when you also want to send a notification, or when the reaction depends on which task failed.
+
+:::caution
+Do not express the same rule as an *All Tasks in Phase* statement OR-ed with per-task *failed* statements. That shape passes as soon as one of the tolerated tasks fails, even when a task that had to succeed failed as well.
+:::
+
+## Alternative: branch on a single task's status
+
+You can also recreate the behavior with a condition that branches on a task's job status — useful when the failure should trigger a notification. The example below starts from a first phase named **Extract Data** that contains two tasks: a GitHub extractor (**My GitHub**) and a Google Sheets extractor (**Vouchers and Global Bars**).
 
 1. Start with the **Extract Data** phase containing the GitHub and Google Sheets extractor tasks.
 

--- a/src/content/docs/flows/flow-migration-guide/continue-on-failure.md
+++ b/src/content/docs/flows/flow-migration-guide/continue-on-failure.md
@@ -2,30 +2,36 @@
 title: Continue on Failure in Conditional Flows
 slug: 'flows/flow-migration-guide/continue-on-failure'
 description: >-
-  Conditional Flows have no per-task Continue on Failure toggle, so the Legacy
-  Flow "continue on failure + warning notification" behavior is not migrated
-  automatically. Learn how to reproduce it using conditions.
+  Conditional Flows have no per-task Continue on Failure toggle. The Legacy Flow
+  behavior is migrated into a Continue on Failure condition on the phase; learn
+  what the migration produces and how to build or extend it yourself.
 ---
 
-When you migrate a [Legacy Flow](/flows/flows-legacy/) to a [Conditional Flow](/flows/) using the [Migration Guide](/flows/flow-migration-guide/), the **Continue on Failure** behavior does not carry over automatically. This page explains why and shows how to reproduce it with conditions.
+In [Legacy Flows](/flows/flows-legacy/), enabling **Continue on Failure** on a task made the task finish with a **warning** status instead of failing the whole Flow. [Conditional Flows](/flows/) have no per-task toggle - the same rule is expressed with a [condition](/flows/#conditions) on the phase.
 
-:::caution[Known issue]
-In Legacy Flows, enabling **Continue on Failure** on a task made the task finish with a **warning** status instead of failing the whole Flow, and could send a warning notification. Conditional Flows have no per-task toggle — the behavior is expressed with [conditions](/flows/#conditions) — and it is not migrated automatically, so you have to rebuild it manually.
-:::
+## What the migration produces
 
-## Recommended: the Continue on Failure condition subject
+When you migrate a Legacy Flow using the [Migration Guide](/flows/flow-migration-guide/), tasks with **Continue on Failure** enabled are translated into a **Continue on Failure** condition on their phase: all tasks of the phase must succeed, except those that had the toggle on. You don't have to rebuild anything manually.
 
-Add a condition to the phase and pick **Continue on Failure** as its [subject](/flows/#4-continue-on-failure) — the phase, then **Continue on Failure** — and select the tasks that are allowed to fail. Every other task in the phase must succeed for the branch to be taken.
-
-This is the closest equivalent of the Legacy Flow toggle and the option to reach for first. Use the branching described below when you also want to send a notification, or when the reaction depends on which task failed.
+You can review and change the result in the Builder - the condition uses the [Continue on Failure](/flows/#4-continue-on-failure) subject, and the tasks allowed to fail are listed in the **All tasks of the phase must succeed, except** selector.
 
 :::caution
-Do not express the same rule as an *All Tasks in Phase* statement OR-ed with per-task *failed* statements. That shape passes as soon as one of the tolerated tasks fails, even when a task that had to succeed failed as well.
+Flows migrated **before** this behavior was introduced carry an older condition shape: an *All Tasks in Phase* statement combined with per-task *failed* statements using **OR**. That shape passes as soon as one of the tolerated tasks fails, even when a task that had to succeed failed as well. Such flows are not rewritten automatically - if you rely on the behavior, replace the condition with the **Continue on Failure** subject.
 :::
 
-## Alternative: branch on a single task's status
+## Build it yourself
 
-You can also recreate the behavior with a condition that branches on a task's job status — useful when the failure should trigger a notification. The example below starts from a first phase named **Extract Data** that contains two tasks: a GitHub extractor (**My GitHub**) and a Google Sheets extractor (**Vouchers and Global Bars**).
+You can add the same condition to any phase, whether it came from a migration or not:
+
+1. Add a condition to the phase.
+2. As the subject, pick the phase and then **Continue on Failure**.
+3. In the **All tasks of the phase must succeed, except** selector, pick the tasks that are allowed to fail.
+
+Every other task in the phase must succeed for the branch to be taken. Leave the selector empty to require that the whole phase succeeds.
+
+## Notify when a task fails
+
+If you also want to be notified, branch on the failing task's status and route the Flow through a phase with a **Notification** task. The example below starts from a first phase named **Extract Data** that contains two tasks: a GitHub extractor (**My GitHub**) and a Google Sheets extractor (**Vouchers and Global Bars**).
 
 1. Start with the **Extract Data** phase containing the GitHub and Google Sheets extractor tasks.
 
@@ -52,5 +58,5 @@ You can also recreate the behavior with a condition that branches on a task's jo
    ![The resulting Flow: the Notification branch rejoins Phase 2](/flows/flow-migration-guide/continue-on-failure-6.png)
 
 :::caution
-Any task that does **not** have a condition on the *failed* status — such as the Google Sheets extractor in this example — still fails the whole Flow if it finishes with an error. Add a failed-status condition to every task that should be allowed to continue on failure.
+A per-task branch like this only covers the task it is attached to. Any other task of the phase - such as the Google Sheets extractor in this example - still fails the whole Flow if it finishes with an error. Use the **Continue on Failure** subject to allow several tasks to fail at once.
 :::

--- a/src/content/docs/flows/flow-migration-guide/index.md
+++ b/src/content/docs/flows/flow-migration-guide/index.md
@@ -41,7 +41,7 @@ The preview opens a side-by-side view: the **Current Legacy Flow** on the left a
 Use this view to:
 
 - Verify that all phases and tasks from the original Legacy Flow are represented in the Conditional Flow.
-- Read through the structural changes so you understand how Legacy Flow concepts (such as the **Continue on Failure** toggle) have been translated into Conditional Flow primitives. Conditional Flows have no **Continue on Failure** toggle; see [Continue on Failure in Conditional Flows](/flows/flow-migration-guide/continue-on-failure/) for how to reproduce that behavior with conditions.
+- Read through the structural changes so you understand how Legacy Flow concepts (such as the **Continue on Failure** toggle) have been translated into Conditional Flow primitives. Conditional Flows have no per-task **Continue on Failure** toggle - the behavior is migrated into a condition on the phase; see [Continue on Failure in Conditional Flows](/flows/flow-migration-guide/continue-on-failure/).
 
 The preview is read-only. No changes are made to your project until you explicitly start the migration.
 

--- a/src/content/docs/flows/index.md
+++ b/src/content/docs/flows/index.md
@@ -46,7 +46,7 @@ You can also set up parallelization **within a component** (configuration), dire
 
 - If you need to temporarily skip something, disable the task. The task will then be excluded from the flow.
 
-- Failure handling is expressed through [conditions](#conditions) instead of a "Continue on Failure" toggle — you can branch on task or phase status (e.g., `if status == 'error' then ...`) to send notifications, run fallback logic, or end the flow. See also [Retry](#retry) for automatic retries of failed tasks.
+- Failure handling is expressed through [conditions](#conditions) instead of a "Continue on Failure" toggle — you can branch on task or phase status (e.g., `if status == 'error' then ...`) to send notifications, run fallback logic, or end the flow. To let selected tasks fail while the rest of the phase must succeed, use the [Continue on Failure](#4-continue-on-failure) condition subject. See also [Retry](#retry) for automatic retries of failed tasks.
 
 - To modify the parameters sent to the underlying [API call](https://developers.keboola.com/integrate/jobs/#run-a-job), you can set **Task Parameters**.
 Select the task and click **Set advanced parameters**. When finished, click **Set**.
@@ -112,6 +112,7 @@ In the **Phases / Tasks** tab you can choose:
 | ***phase* > Whole Phase Status** | The resulting status of the whole phase. |
 | ***phase* > All Tasks in Phase** | Passes only when **every** task in that phase matches. |
 | ***phase* > Any Task in Phase** | Passes when **at least one** task in that phase matches. |
+| ***phase* > Continue on Failure** | Passes when **every** task in that phase succeeded, except the tasks you explicitly allow to fail. See [Continue on Failure](#4-continue-on-failure). |
 | ***phase* > *task*** | A single field from that task's job result (browse the result tree, as with [Dynamic Value](#dynamic-value) variables). |
 
 For the aggregated subjects (*Any Task in the Flow*, *All Tasks in Phase*, *Any Task in Phase*), the field is picked from a short list that applies to any task: **Job Status**, **Job Duration**, **Error Message**, **Count of output tables**, **Sum of imported rows**, and **Min of imported rows**.
@@ -122,7 +123,7 @@ When you pick a specific phase or task, you can only reference phases that run *
 A condition can only ever look at tasks that have **already finished** at the moment it is evaluated. *Any Task in the Flow* therefore silently ignores tasks in phases that have not run yet - it never waits for them.
 :::
 
-The typical use case is a single flow-level error branch - *"if any task in the flow ended with an error, send a notification"* - instead of repeating an *Any Task in Phase* statement for every phase.
+The typical use case for *Any Task in the Flow* is a single flow-level error branch - *"if any task in the flow ended with an error, send a notification"* - instead of repeating an *Any Task in Phase* statement for every phase.
 
 **JSON equivalent** (useful when authoring a flow as a template or via the API) - the aggregated subjects wrap the inner statement, which uses `*` as the task:
 
@@ -144,6 +145,31 @@ The typical use case is a single flow-level error branch - *"if any task in the 
 ```
 
 The per-phase variants use the same shape with the `ANY_TASKS_IN_PHASE` or `ALL_TASKS_IN_PHASE` operator plus a `"phase": "<phase-id>"` property.
+
+### 4. Continue on Failure
+
+**Continue on Failure** is a subject of its own, picked per phase next to *All Tasks in Phase* and *Any Task in Phase*. It expresses *"these tasks may fail, all the others must succeed"* - the equivalent of the **Continue on Failure** toggle known from [Legacy Flows](/flows/flows-legacy/).
+
+After selecting it, pick the tasks that are allowed to fail in the **All tasks of the phase must succeed, except** selector. The statement then passes when every other task in the phase finished successfully; a task blocks the branch only if it did **not** succeed **and** is not on the list. Leave the list empty to require that the whole phase succeeds.
+
+The condition is summarized as *All tasks in Extract Data succeeded / except My GitHub*.
+
+:::tip
+Use this subject instead of combining an *All Tasks in Phase* statement with per-task *failed* statements using **OR**. Such a combination passes as soon as one of the tolerated tasks fails - even when a task that had to succeed failed as well.
+:::
+
+**JSON equivalent** - the operator takes no `operands`, because the statuses are fixed. It carries the ids of the tolerated tasks instead:
+
+```json
+{
+  "type": "operator",
+  "operator": "CONTINUE_ON_FAILURE",
+  "phase": "8888",
+  "tasks": ["456", "789"]
+}
+```
+
+Task ids that no longer belong to the phase (for example a deleted or disabled task) are ignored, so the condition keeps working when the phase's tasks change.
 
 ## Variables
 

--- a/src/content/docs/flows/index.md
+++ b/src/content/docs/flows/index.md
@@ -81,6 +81,8 @@ Control the flow of execution based on conditions like:
 - **Number of Output Tables** - control the flow based on how many output tables a task produces.
 - **Duration of Task** - condition to trigger actions depending on how long a task runs. This is useful for detecting anomalies (e.g., unusually short or long runtimes).
 
+Each of these can be evaluated for a single task, a whole phase, all or any task in a phase, or any task in the whole flow - see [What the Condition Compares](#3-what-the-condition-compares-subject).
+
 Evaluation proceeds from top to bottom, and once a condition is true, the remaining conditions are ignored - even if others would also evaluate to be true.
 
 :::caution
@@ -97,6 +99,51 @@ You can use logical operators (AND) and (OR) to combine multiple statements with
 - Use **(OR)** when any one statement being true is enough.
 
 ![](/flows/conditional-flows-condition.png)
+
+### 3. What the Condition Compares (Subject)
+
+Every statement starts with a **subject** - the thing the flow looks at. The picker offers two tabs: **Phases / Tasks** and **Variables** (see [Using Variables in Conditions](#using-variables-in-conditions)).
+
+In the **Phases / Tasks** tab you can choose:
+
+| Subject | What it evaluates |
+| --- | --- |
+| **Any Task in the Flow** | A flow-level row above the phase list. The statement passes when **at least one** finished task anywhere in the flow matches. |
+| ***phase* > Whole Phase Status** | The resulting status of the whole phase. |
+| ***phase* > All Tasks in Phase** | Passes only when **every** task in that phase matches. |
+| ***phase* > Any Task in Phase** | Passes when **at least one** task in that phase matches. |
+| ***phase* > *task*** | A single field from that task's job result (browse the result tree, as with [Dynamic Value](#dynamic-value) variables). |
+
+For the aggregated subjects (*Any Task in the Flow*, *All Tasks in Phase*, *Any Task in Phase*), the field is picked from a short list that applies to any task: **Job Status**, **Job Duration**, **Error Message**, **Count of output tables**, **Sum of imported rows**, and **Min of imported rows**.
+
+Only phases that run **before** the condition (plus the condition's own phase) can be referenced. *Any Task in the Flow* is the exception - it is flow-level and not limited to upstream phases.
+
+:::caution
+*Any Task in the Flow* evaluates only tasks that have **already finished** at the moment the condition is evaluated. Tasks in phases that have not run yet are ignored.
+:::
+
+The typical use case is a single flow-level error branch - *"if any task in the flow ended with an error, send a notification"* - instead of repeating an *Any Task in Phase* statement for every phase.
+
+**JSON equivalent** (useful when authoring a flow as a template or via the API) - the aggregated subjects wrap the inner statement, which uses `*` as the task:
+
+```json
+{
+  "type": "operator",
+  "operator": "ANY_TASKS_IN_ANY_PHASE",
+  "operands": [
+    {
+      "type": "operator",
+      "operator": "EQUALS",
+      "operands": [
+        { "type": "task", "task": "*", "value": "job.status" },
+        { "type": "const", "value": "error" }
+      ]
+    }
+  ]
+}
+```
+
+The per-phase variants use the same shape with the `ANY_TASKS_IN_PHASE` or `ALL_TASKS_IN_PHASE` operator plus a `"phase": "<phase-id>"` property.
 
 ## Variables
 

--- a/src/content/docs/flows/index.md
+++ b/src/content/docs/flows/index.md
@@ -108,7 +108,7 @@ In the **Phases / Tasks** tab you can choose:
 
 | Subject | What it evaluates |
 | --- | --- |
-| **Any Task in the Flow** | A flow-level row above the phase list. The statement passes when **at least one** finished task anywhere in the flow matches. |
+| **Any Task in the Flow** | A flow-level row above the phase list. The statement passes when **at least one** already finished task anywhere in the flow matches. |
 | ***phase* > Whole Phase Status** | The resulting status of the whole phase. |
 | ***phase* > All Tasks in Phase** | Passes only when **every** task in that phase matches. |
 | ***phase* > Any Task in Phase** | Passes when **at least one** task in that phase matches. |
@@ -116,10 +116,10 @@ In the **Phases / Tasks** tab you can choose:
 
 For the aggregated subjects (*Any Task in the Flow*, *All Tasks in Phase*, *Any Task in Phase*), the field is picked from a short list that applies to any task: **Job Status**, **Job Duration**, **Error Message**, **Count of output tables**, **Sum of imported rows**, and **Min of imported rows**.
 
-Only phases that run **before** the condition (plus the condition's own phase) can be referenced. *Any Task in the Flow* is the exception - it is flow-level and not limited to upstream phases.
+When you pick a specific phase or task, you can only reference phases that run **before** the condition (plus the condition's own phase). *Any Task in the Flow* needs no phase at all, so it also covers tasks in parallel branches that already finished - not just the ones directly upstream.
 
 :::caution
-*Any Task in the Flow* evaluates only tasks that have **already finished** at the moment the condition is evaluated. Tasks in phases that have not run yet are ignored.
+A condition can only ever look at tasks that have **already finished** at the moment it is evaluated. *Any Task in the Flow* therefore silently ignores tasks in phases that have not run yet - it never waits for them.
 :::
 
 The typical use case is a single flow-level error branch - *"if any task in the flow ended with an error, send a notification"* - instead of repeating an *Any Task in Phase* statement for every phase.


### PR DESCRIPTION
Jira issue(s): [AJDA-3059](https://linear.app/keboola/issue/AJDA-3059/ui-add-ui-for-anytasksinanyphaseoperator-operator) ([keboola/ui#7468](https://github.com/keboola/ui/pull/7468), [job-queue-daemon#903](https://github.com/keboola/job-queue-daemon/pull/903)), [AJDA-3065](https://linear.app/keboola/issue/AJDA-3065/continue-on-failure-ux) ([keboola/ui#7545](https://github.com/keboola/ui/pull/7545), [job-queue-daemon#908](https://github.com/keboola/job-queue-daemon/pull/908)), [AJDA-3085](https://linear.app/keboola/issue/AJDA-3085/flow-migration-tool-emit-continue-on-failure-operator-in) ([flow-migration-tool#30](https://github.com/keboola/flow-migration-tool/pull/30))

The `## Conditions` section on /flows/ listed only what a condition can compare (status, variables, date/time, output tables, duration) — it never covered **scoping**. So the pre-existing *Whole Phase Status* / *All Tasks in Phase* / *Any Task in Phase* aggregators were undocumented, and the two new operators had nowhere to land. The migration guide's Continue on Failure page was also still written as a known issue with a manual workaround.

Changes:

- **New `### 3. What the Condition Compares (Subject)`** in `flows/index.md` — a table of the six subjects selectable in the **Phases / Tasks** tab, the field list offered for the aggregated subjects (Job Status, Job Duration, Error Message, Count of output tables, Sum/Min of imported rows), and the phase-reference rules.
- **`ANY_TASKS_IN_ANY_PHASE`** — documented as *Any Task in the Flow*. Framed as "no phase needed, so it also covers already finished tasks in parallel branches" rather than "not limited to upstream phases": a condition can never look at a task that has not finished, so the picker's lack of a phase filter must not read as "it can see phases that haven't run". A caution states it silently ignores tasks in phases that have not run yet and never waits for them (the daemon's `isStopped()` filter; `FlowContext` also carries `new` tasks, e.g. the notification task the condition routes to).
- **New `### 4. Continue on Failure`** for `CONTINUE_ON_FAILURE` — the per-phase subject plus the **All tasks of the phase must succeed, except** selector, the *"a task blocks the branch only if it did not succeed **and** is not listed"* rule, the empty-list case, the edge-label summary, and the fact that stale task ids are ignored (the daemon ignores ids not in the phase, so disabling or deleting a task must not break a migrated flow).
- **`flow-migration-guide/continue-on-failure.md` rewritten** — the Legacy Flow toggle is now migrated automatically into a *Continue on Failure* condition on the phase, so the page leads with what the migration produces instead of a known-issue box and a manual rebuild. The hand-built per-task branch survives as "Notify when a task fails" (its screenshots still match), and the closing caution now explains why that branch alone is not equivalent.
- A caution that flows migrated **before** this change keep the old `OR(ALL_TASKS_IN_PHASE → success, task.X == error)` shape, which passes as soon as a tolerated task fails even when a required one failed too, and that they are not rewritten automatically.
- JSON equivalents for both operators, matching the style already used in the Variables section, plus pointers from the existing condition-types list, from **Control Task Execution**, and from the migration guide's preview step.

---

Notes:

- No screenshots, per request — description only.
- `npm run build` clean (256 pages); `node scripts/audit-phase2.mjs` reports no new findings (broken-link count unchanged at 3, all pre-existing and on other pages); anchors render as `#3-what-the-condition-compares-subject` and `#4-continue-on-failure`.
- **Release gate.** The page now describes the automatic migration, which ships with [flow-migration-tool#30](https://github.com/keboola/flow-migration-tool/pull/30) (open, and gated on `CONTINUE_ON_FAILURE` being deployed to all stacks). [keboola/ui#7545](https://github.com/keboola/ui/pull/7545) is also still open. Hold this PR until both have shipped.

## Release Notes
**Justification, description**

Documents conditional-flow condition scoping, the new flow-level `ANY_TASKS_IN_ANY_PHASE` operator, and the `CONTINUE_ON_FAILURE` operator that replaces the Legacy Flow *Continue on Failure* toggle and is now emitted by the migration.

**Plans for Customer Communication**

N/A

**Impact Analysis**

Documentation only.

**Deployment Plan**

Merge once the UI and flow-migration-tool changes have shipped to all stacks.

**Rollback Plan**

N/A

**Post-Release Support Plan**

N/A


Link to Devin session: https://app.devin.ai/sessions/182a2ad065a0486c8aa1e367bdc31231
Requested by: @natocTo