### PR TITLE
docs: document Direct Mode output mapping in Snowflake/BigQuery workspaces

### DIFF
--- a/src/content/docs/transformations/mappings/index.md
+++ b/src/content/docs/transformations/mappings/index.md
@@ -390,11 +390,9 @@ production-quality SQL and managing data consistency themselves. Typical use cas
 
 #### Supported Backends
 Direct Mode output mapping is available for any component that uses a **Snowflake** or **BigQuery** workspace,
-including [transformations](/transformations/) and [data apps](/components/data-apps/). 
-
-:::caution
-Workspaces (standalone or via SQL editor) are not supported for time being.
-:::
+including [transformations](/transformations/), [data apps](/components/data-apps/), and
+[workspaces](/workspace/) --- both standalone Snowflake/BigQuery workspaces and workspaces opened in the
+[SQL Editor](/workspace/sql-editor/).
 
 #### How It Works
 When a component with Direct Mode output mapping runs:
@@ -404,6 +402,10 @@ When a component with Direct Mode output mapping runs:
    (e.g., `"KBC_USE4_33"."in.c-raw-data"."my-table"`).
 3. After the transformation finishes, Keboola runs a **refresh job** that updates table metadata,
    row counts, and statistics. No data is copied --- the changes are already in place.
+
+In a **workspace**, there is no job to wait for: the write privileges are granted as soon as you save the
+Direct Mode output mapping, so you can write to the Storage table from your very next query. Removing the
+mapping revokes the privileges again.
 
 The workspace receives these privileges on each granted table:
 - `SELECT`, `INSERT`, `UPDATE`, `DELETE`, `TRUNCATE` (Snowflake)
@@ -415,8 +417,13 @@ The workspace **cannot**:
 - Write to tables not listed in the output mapping
 
 #### Configuration
-Direct Mode output mapping is configured per output table in the transformation configuration JSON.
-To set it up, switch to the JSON editor in the output mapping section and add the `unload_strategy` field:
+In Snowflake and BigQuery transformations and workspaces, add an output mapping and switch the mode from
+**Guided Mode** to **Direct Mode**. Pick an existing Storage table as the destination; the dialog then shows the
+full table path to copy into your SQL.
+
+The mode cannot be switched on an existing mapping --- delete the mapping and create a new one instead.
+
+Under the hood, Direct Mode is the `unload_strategy` field on the output table in the configuration JSON:
 
 ```json
 {
@@ -439,6 +446,27 @@ The `unload_strategy` field accepts two values:
 
 You can mix both strategies in a single transformation --- some tables can use Direct Mode output mapping while
 others use the standard copy strategy.
+
+#### Workspaces
+In a workspace, Direct Mode output mapping replaces the **Unload Data** round trip --- you write to the Storage
+table directly from the workspace instead of loading data into Storage afterwards.
+
+In a **standalone Snowflake or BigQuery workspace**, open the **Output Mapping** section in the workspace detail,
+add an output, and select **Direct Mode**.
+
+In the **[SQL Editor](/workspace/sql-editor/)**, you can also create the destination table on the fly:
+
+1. In the **Working Tables** section, click the three dots next to a working table and select **Create writable table**.
+2. Set the destination bucket and table name, adjust the column definitions and the primary key.
+3. Click **CREATE WRITABLE TABLE**.
+
+Keboola creates the Storage table (creating the bucket first if it does not exist yet) and registers it as a
+Direct Mode output mapping. The source working table itself is not modified or copied --- only its column
+structure is used as the template for the new Storage table.
+
+The new table appears in the **Writable tables** section of the Storage Explorer with the **DG** badge, and the
+workspace can write to it right away. Use the three-dots menu there to remove the mapping (and with it the
+workspace's write access).
 
 #### Good Practices
 

--- a/src/content/docs/workspace/index.md
+++ b/src/content/docs/workspace/index.md
@@ -284,6 +284,10 @@ For Snowflake and BigQuery workspaces, you can also export a single table direct
 [File Storage](/storage/files/) via the Storage API. See
 [Exporting Workspace Tables to Files](/workspace/table-export/) for details.
 
+Snowflake and BigQuery workspaces can also skip unloading entirely and write to a Storage table directly with
+[Direct Mode output mapping](/transformations/mappings/#direct-mode-output-mapping). The workspace gets write
+access to the selected table as soon as the mapping is saved, so no **Unload Data** run is needed.
+
 ### Data Persistency (beta)
 When this feature is enabled in a project, your data in workspaces can be kept. This way you can, when you return, start where you left off without losing data or time by importing the data again or executing scripts to get to the right stage.
 

--- a/src/content/docs/workspace/sql-editor/index.md
+++ b/src/content/docs/workspace/sql-editor/index.md
@@ -175,6 +175,30 @@ Once mapped, the table icon in the Working Tables section changes to **OM** (Out
 
 ![SQL Editor - Working Tables section showing OM (Output Mapping) table](/workspace/sql-editor/14-working-tables-om.jpg)
 
+### Writing Directly to Storage (Direct Mode)
+
+On Snowflake and BigQuery workspaces, you can skip the copy step altogether and let the workspace write straight
+into a Storage table using [Direct Mode output mapping](/transformations/mappings/#direct-mode-output-mapping).
+
+1.  In the **Working Tables** section, click the three dots next to a working table and select
+    **Create writable table**.
+2.  Set the destination bucket and table name in Storage, and adjust the column definitions and the primary key.
+3.  Click **CREATE WRITABLE TABLE**.
+
+Keboola creates the Storage table (creating the bucket first if it does not exist yet) and registers it as a
+Direct Mode output mapping, which grants the workspace write access to that table. The working table you started
+from is used only as the template for the column structure --- it is not copied or modified.
+
+The new table shows up in the **Writable tables** section of the Storage Explorer with the **DG** badge, and you
+can `INSERT`, `UPDATE`, `DELETE`, or `TRUNCATE` it from your next query. Use the three-dots menu there to remove
+the mapping, which also revokes the workspace's write access.
+
+:::caution
+In Direct Mode, you are responsible for deduplication, data types, and error handling --- Keboola performs no
+validation on direct writes. Read the
+[good and bad practices](/transformations/mappings/#good-practices) before using it in production.
+:::
+
 ### Saving Queries as a Transformation
 
 To persist the SQL logic and output mapping into a formal Keboola Transformation:


### PR DESCRIPTION
Jira issue(s): PROOF-XXX

Direct Grant (Direct Mode) output mapping now works in Snowflake/BigQuery workspaces and in the SQL Editor — merged today in keboola/ui#6716 (`supportsSqlOutputMapping` now returns true for `keboola.sandboxes`, plus the new **Create writable table** flow and **Writable tables** section in the SQL Editor catalog). The docs still said workspaces were unsupported and that Direct Mode is JSON-only.

Changes:

- `transformations/mappings/index.md`: dropped the "Workspaces (standalone or via SQL editor) are not supported" caution, added workspaces to Supported Backends, noted that in a workspace grants apply on save (no job to wait for) and are revoked when the mapping is removed, rewrote **Configuration** to lead with the UI (Guided Mode / Direct Mode radio, mode not switchable on an existing mapping) with the `unload_strategy` JSON as the underlying representation, and added a **Workspaces** subsection covering the standalone workspace Output Mapping section and the SQL Editor **Create writable table** flow (bucket auto-created, working table used only as a column template, DG badge).
- `workspace/sql-editor/index.md`: new "Writing Directly to Storage (Direct Mode)" section with the step-by-step Create writable table flow and a caution about no validation/deduplication.
- `workspace/index.md`: Unloading Data now points out that Snowflake/BigQuery workspaces can skip **Unload Data** via Direct Mode.

---

Open questions for review (product facts I didn't want to guess):

- For transformations, a refresh job updates row counts/statistics after the job. In a workspace there is no job — does anything refresh the Storage table metadata after a direct write, or does the user need to trigger it? Docs currently stay silent on this.
- Direct Mode is still gated by the `direct-grant-output-mapping` project feature (the UI shows a "request feature" button). The page still calls it a private beta enabled by Support — confirm that's still the wording you want.
- No screenshots added for the new workspace/SQL Editor flows; happy to capture them if wanted.


Link to Devin session: https://app.devin.ai/sessions/89472b6b1cda4b30a50e39389ca8b338
Requested by: @natocTo