### PR TITLE
PRDCT-545: encode the de-duplication and no-AI-IA migration rules in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,3 +23,19 @@ The full repo guide — stack, structure, commands, and conventions — lives in
 - **Screenshots:** save throwaways to `/tmp`, not the repo. `scripts/screenshot.mjs`
   is a local-only helper (gitignored).
 - **Ask a maintainer** for product facts vs. content choices instead of guessing.
+
+## Migrating dev docs into help (Jordan, 2026-07-30)
+
+- **De-duplicate, never add-alongside.** Moving a page is not the goal; *unifying* is.
+  Lifecycle: merge the information into the help page → update the links pointing at it →
+  then kill/redirect the old page. If a competing overview survives, the migration is not
+  done. Before placing anything, search for where that concept **already lives** (expand every
+  `**/other/` nav subgroup — thin stubs hide there) and dedup into **one** canonical page.
+- **Never let an agent decide information architecture.** Placement is a human call made
+  against the **live preview**; automated audit output is evidence, not a verdict. Recommend a
+  home and **surface the decision** — don't self-place cross-cutting features. Use the
+  `migration-placement` skill; it encodes this and the known failure cases.
+- **Never hard-delete a dev page without checking what links to it**
+  (`gh search code "developers.keboola.com/<section>" --owner keboola`, plus non-GitHub
+  callers). Some sections have hundreds of inbound references — see the scan table in
+  `DEV-MIGRATION-PLAN.md`.


### PR DESCRIPTION
From the **2026-07-30 sync**. These rules lived only in a call note, so sessions that never read it kept doing the thing you objected to — placing migrated content at the first name-matching spot and adding it *alongside* the existing help page, leaving duplicate overviews behind.

Three rules added under a new `## Migrating dev docs into help` heading:

1. **De-duplicate, never add-alongside.** Lifecycle: merge into the help page → update inbound links → then kill/redirect the old page. Search where the concept already lives first, including the hidden `**/other/` nav subgroups where thin stubs hide.
2. **Never let an agent decide information architecture.** Placement is a human call against the live preview; audit output is evidence, not a verdict. Recommend and surface — don't self-place cross-cutting features.
3. **Never hard-delete a dev page without scanning inbound links.** The 2026-08-03 scan found **210** files linking to `/extend/component` and **65** to `/extend/common-interface` across the `keboola` org alone — so "broken inbound links are acceptable" no longer holds for those sections.

Docs-only, no build impact.

Related: #1000 (broader CLAUDE.md house-style pass, still draft) · `.claude/skills/migration-placement/` (the skill these rules point at).

🤖 Generated with [Claude Code](https://claude.com/claude-code)