### PR TITLE
docs: mark Direct Mode output mapping as beta

### DIFF
--- a/src/content/docs/transformations/mappings/index.md
+++ b/src/content/docs/transformations/mappings/index.md
@@ -367,7 +367,11 @@ user receives write privileges on specific Storage tables. Any `INSERT`, `UPDATE
 or `TRUNCATE` you run in your transformation SQL can be applied immediately to the destination table --- there is no
 separate import step.
 
-This feature is available as a **private beta** and must be enabled by [Keboola Support](/management/support/).
+This feature must be enabled by [Keboola Support](/management/support/).
+
+:::caution[Beta]
+This feature is currently in beta. Please provide feedback using the feedback button in your project.
+:::
 
 ![Direct Mode Output Mapping](/transformations/mappings/manual-output-mapping.png)
 


### PR DESCRIPTION
Jira issue(s): PROOF-XXX

Direct Mode (direct grant) output mapping is a beta feature, but the docs only mentioned it in a plain sentence. Adds a highlighted admonition, matching the one used for [development branches](https://help.keboola.com/extend/common-interface/development-branches/#_top).

Changes:

- `transformations/mappings`: replace the "available as a **private beta**" phrasing with a `:::caution[Beta]` box ("This feature is currently in beta. Please provide feedback using the feedback button in your project."), keeping the "must be enabled by Keboola Support" note.

---

Wording says "beta" rather than "public beta" since the feature still needs to be enabled by Support — happy to switch to "public beta" if that's the intended stage. A matching in-product notice is added in keboola/ui.


Link to Devin session: https://app.devin.ai/sessions/459c1bbd376649c3871dd432121dab75
Requested by: @terezaskalova
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/connection-docs/pull/1068" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->