### PR TITLE
feat(audit): validate link anchors, not just link paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,8 @@ Images: place alongside the Markdown and reference with an absolute path
 
 - `npm run build` is clean (no fatal errors).
 - For link/image/table changes, run `node scripts/audit-phase2.mjs` after building.
+  It also validates link **anchors** (`BROKEN LINK ANCHORS`), so run it after
+  renaming any heading — a rename silently breaks every link into that section.
 - For CSS that must survive client-side navigation, verify in a **production
   build** (`astro build && astro preview`) — dev injects `<style>` tags that
   don't survive Astro view-transition swaps.

--- a/scripts/audit-phase2.mjs
+++ b/scripts/audit-phase2.mjs
@@ -37,20 +37,63 @@ function walk(dir, test) {
 const htmlFiles = walk(DIST, (f) => f.endsWith('.html') && !f.includes('/pagefind/'));
 const route = (f) => '/' + relative(DIST, f).replace(/index\.html$/, '').replace(/\.html$/, '');
 
-// Resolve whether an internal absolute path exists in the build output.
-function resolves(p) {
+// Build-output candidates that could serve an internal absolute path.
+function candidates(p) {
   p = p.split('#')[0].split('?')[0];
-  if (!p) return true;
-  const cands = [
+  if (!p) return [];
+  return [
     join(DIST, p),
     join(DIST, p, 'index.html'),
     join(DIST, p.replace(/\/$/, '') + '.html'),
     join(DIST, p.replace(/\/$/, '') + '/index.html'),
   ];
-  return cands.some(existsSync);
 }
 
-const findings = { brokenLinks: [], missingImages: [], jekyllSmell: [], multiH1: [], extCount: 0 };
+// Resolve whether an internal absolute path exists in the build output.
+function resolves(p) {
+  const cands = candidates(p);
+  return cands.length === 0 || cands.some(existsSync);
+}
+
+// Resolve to the HTML file that serves the path, or null. A bare directory
+// exists but cannot be read, so only file candidates count here.
+function resolveFile(p) {
+  return candidates(p).find((f) => existsSync(f) && statSync(f).isFile()) ?? null;
+}
+
+// Element ids per built page, for validating link fragments. Parsed from the
+// <body> only, same as the link scan, and memoised — pages are read many times.
+const idCache = new Map();
+function idsOf(file) {
+  if (!idCache.has(file)) {
+    const raw = readFileSync(file, 'utf8');
+    const bi = raw.search(/<body[\s>]/i);
+    const body = bi >= 0 ? raw.slice(bi) : raw;
+    idCache.set(file, {
+      ids: new Set([...body.matchAll(/\sid="([^"]+)"/g)].map((m) => m[1])),
+      // a redirect_from stub has no headings at all, so any anchor into it is dead
+      isStub: /http-equiv="refresh"/i.test(raw),
+    });
+  }
+  return idCache.get(file);
+}
+
+// `_top` and Starlight's own scaffolding ids are synthetic, not authored anchors.
+const realAnchor = (frag) => frag && frag !== '_top' && !frag.startsWith('starlight__');
+
+function checkAnchor(page, url, targetFile, frag) {
+  const { ids, isStub } = idsOf(targetFile);
+  if (ids.has(decodeURIComponent(frag))) return;
+  findings.brokenAnchors.push({
+    page,
+    url,
+    kind: isStub ? 'anchor-on-redirect-stub' : 'missing-anchor',
+  });
+}
+
+const findings = {
+  brokenLinks: [], brokenAnchors: [], missingImages: [], jekyllSmell: [], multiH1: [], extCount: 0,
+};
 
 const ATTR = /(?:href|src)\s*=\s*["']([^"']+)["']/gi;
 
@@ -72,7 +115,13 @@ for (const file of htmlFiles) {
     const url = m[1].trim();
     const isImg = m[0].toLowerCase().startsWith('src');
 
-    if (/^(mailto:|tel:|javascript:|data:|#)/i.test(url)) continue;
+    if (/^#/.test(url)) {
+      // same-page anchor: validate against this page's own ids
+      const frag = url.slice(1);
+      if (realAnchor(frag)) checkAnchor(r, url, file, frag);
+      continue;
+    }
+    if (/^(mailto:|tel:|javascript:|data:)/i.test(url)) continue;
     if (/^https?:\/\//i.test(url)) {
       findings.extCount++;
       // old-docs / Jekyll smell: absolute links back to the legacy docs host
@@ -94,6 +143,14 @@ for (const file of htmlFiles) {
       } else {
         findings.brokenLinks.push({ page: r, url });
       }
+      continue;
+    }
+
+    // the path resolves — now check the fragment, if any, against the target page
+    const frag = url.split('#')[1];
+    if (!isImg && realAnchor(frag)) {
+      const target = resolveFile(url);
+      if (target) checkAnchor(r, url, target, frag);
     }
   }
 }
@@ -138,12 +195,14 @@ const dump = (title, arr, fmt) => {
 };
 
 dump('BROKEN INTERNAL LINKS', findings.brokenLinks, (x) => `${x.page}  →  ${x.url}`);
+dump('BROKEN LINK ANCHORS', findings.brokenAnchors, (x) => `[${x.kind}] ${x.page}  →  ${x.url}`);
 dump('MISSING IMAGES', findings.missingImages, (x) => `${x.page}  →  ${x.url}`);
 dump('JEKYLL / OLD-DOCS LINK SMELLS', findings.jekyllSmell, (x) => `[${x.kind}] ${x.page}  →  ${x.url}`);
 dump('MULTIPLE <h1> PER PAGE', findings.multiH1, (x) => `${x.page}  (${x.count} h1)`);
 dump('UNCLOSED CODE FENCES (source)', fenceIssues, (x) => `${x.file}  (${x.fences} fences)`);
 dump('MALFORMED TABLES (source)', tableIssues, (x) => `${x.file}:${x.line}  header=${x.header} sep=${x.sep}`);
 
-const total = findings.brokenLinks.length + findings.missingImages.length +
-  findings.jekyllSmell.length + findings.multiH1.length + fenceIssues.length + tableIssues.length;
+const total = findings.brokenLinks.length + findings.brokenAnchors.length +
+  findings.missingImages.length + findings.jekyllSmell.length + findings.multiH1.length +
+  fenceIssues.length + tableIssues.length;
 console.log(head(`TOTAL ISSUES: ${total}`));


### PR DESCRIPTION
**Stacked on #1072** (base is `docs/stale-anchors`), so its own output reads 0. On `main` it would report the 73 anchors that #1072 fixes.

`audit-phase2` checked that a link's *path* resolves in `dist/` but never that its `#fragment` exists on the target page — and it skipped same-page `#frag` links entirely (`audit-phase2.mjs:75`). That blind spot is why #1046 shipped dead anchors, and why 73 links had quietly rotted by the time anyone looked: every heading rename since the Jekyll days broke its inbound links silently, with nothing in the build or the audit noticing.

New `BROKEN LINK ANCHORS` section, two kinds:

- **`missing-anchor`** — the fragment has no matching id on the target page, cross-page or same-page.
- **`anchor-on-redirect-stub`** — the target is a `redirect_from` meta-refresh stub, which has no headings at all, so the fragment is dead however plausible the link looks. Three of the 73 hid exactly here: `/transformations/python/`, `/transformations/r/`, `/extractors/other/aws-s3/`.

Implementation:

- `resolves()` keeps its exact semantics (a bare directory still counts as resolving); the candidate list moved into `candidates()`, and the new `resolveFile()` returns only *file* candidates — a directory resolves but can't be read.
- ids are parsed from the `<body>` slice, like the existing link scan, and cached per file.
- `_top` and `starlight__*` are Starlight scaffolding, not authored anchors, so they're ignored; fragments compared after `decodeURIComponent`.
- One line added to AGENTS.md: run the audit after renaming a heading, not just for link/image changes.

---

Verified in a production build:

- **BROKEN LINK ANCHORS: 0** on this branch, and every other category byte-identical — 45 broken internal links / 0 missing images / 101 old-docs smells / 3 multiple-h1 / 0 unclosed fences / 0 malformed tables, total 149.
- Agrees with the standalone checker used to fix the 73 (8480 anchors, 0 broken).
- Proved it actually fires by planting one of each case and reverting:

```
BROKEN LINK ANCHORS: 3
  [missing-anchor] /catalog/  →  /storage/jobs/#no-such-section
  [missing-anchor] /catalog/  →  #no-such-heading-here
  [anchor-on-redirect-stub] /catalog/  →  /transformations/python/#development-tutorial
```

**Not** wired into `.github/workflows/branch.yml`: that gate would also see the 45 pre-existing broken internal links and fail every PR. Worth doing once those are cleaned up — separate decision, separate PR.