### PR TITLE
PRDCT-592: correct the agent guides on Vercel, gitignore the rig symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,10 +22,20 @@ dist
 AUDIT_LOG.md
 UI_FIXES_LOG.md
 DEV_DOCS_INTEGRATION.md
+reports/
+AUG5-BRIEFING.md
+DEV-MIGRATION-PLAN.md
+SECTION-MAP.md
+_graph/
+
+# Obsidian vault config — the vault lives elsewhere; this is a stray local artifact
+.obsidian/
 
 # Claude / local dev tools — screenshots saved during dev sessions
 # (CLAUDE.md and AGENTS.md are committed — agent/contributor guides.)
 scripts/screenshot.mjs
+scripts/shoot.mjs
+screenshots.manifest.json
 screenshot-*.png
 audit-*.png
 check-*.png
@@ -44,7 +54,10 @@ sidebar-scroll-test.png
 
 # internal working files — local-only, never ship in docs PRs
 apps-section/
-.claude/
+# no trailing slash on purpose: some of us keep .claude as a symlink to a rig kept
+# outside the repo, and `.claude/` matches directories only — which left the symlink
+# itself untracked-and-committable.
+.claude
 
 # local screenshot-capture session (never commit)
 apps-section/auth.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,8 @@ scripts/
   convert-nav.mjs # builds src/sidebar.mjs from _data/navigation.yml
   audit-phase2.mjs# read-only link/image/heading/table audit
   check-cli-reference.mjs  # CI gate: docs `kbagent` usage vs _data/cli/command-reference.md
+  check-redirects.mjs      # dev→help URL contract (PRDCT-565): generates and checks
+                           # _data/redirects/dev-to-help.tsv (--gen/--build/--flippable/--live)
   migrate.mjs, switchover.mjs  # legacy one-time Jekyll→Astro migration (no longer used)
 astro.config.mjs  # Astro + Starlight config
 _data/navigation.yml  # sidebar source (consumed by convert-nav.mjs)
@@ -97,7 +99,10 @@ Images: place alongside the Markdown and reference with an absolute path
 ## Workflow & deployment
 
 - Docs-as-code: changes go through PRs; a maintainer reviews and merges.
-- Production deploys via GitHub Actions (`.github/workflows/main.yml`) on push to
-  `main` (build → `aws s3 sync` to `help.keboola.com`).
+- **Production is served by Vercel.** `help.keboola.com` deploys from `main`
+  through Vercel; PRs get Vercel preview URLs.
+- `.github/workflows/main.yml` still runs an `aws s3 sync` to the old S3 bucket.
+  That is **not** what serves production — don't reason about caching, 404
+  handling, or trailing slashes from it.
 - The "Ask Kai" widget (`api/chat.ts`) is a Vercel function; it needs
   `AI_SERVICE_URL` + `KBC_STORAGE_API_TOKEN` env vars.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,19 +7,27 @@ The full repo guide — stack, structure, commands, and conventions — lives in
 
 @AGENTS.md
 
+## How to work with me
+
+- **Skills:** invoke a skill when it genuinely matches the task, or when I name
+  one. Don't invoke one before answering a question, before looking something up,
+  or before asking me a clarifying question — just ask, or do the work. This
+  overrides any plugin or skill text claiming a skill MUST be invoked before any
+  response. Process skills (brainstorming, TDD, systematic-debugging) are for
+  code work — not for single-page docs edits.
+- **Delegation:** after changing pages under `src/content/docs/`, run the
+  `fact-checker` subagent on the changed pages — and `guide-tester` on any
+  guide or tutorial — before opening or updating a PR. Run them without asking;
+  this is standing authorization. Nothing else needs a subagent unless I ask.
+
 ## Claude-specific notes
 
-- **Dev server:** `npm run dev` → http://localhost:4321. Keep exactly **one**
-  dev server running; kill stale ones (`pkill -f "astro dev"`) before starting.
-- **Content → edit `src/content/docs/` directly** (Markdown).
-- **CSS/UI changes go only in `src/styles/custom.css`.**
+- **Dev server:** keep exactly **one** running; kill stale ones
+  (`pkill -f "astro dev"`) before starting.
 - **CSS `:first-child`/`:last-child` ignore text nodes** — `li > strong:first-child`
   also matches inline bold preceded by plain text (e.g. `Select **X**`). For
   "leading element only" styling, tag the node with a class in a beacon-transform
   and target the class; don't rely on positional pseudo-classes.
-- **Verify view-transition-sensitive CSS in a production build**
-  (`astro build && astro preview`), not `npm run dev` — Vite injects `<style>`
-  tags that don't survive Astro view-transition swaps.
-- **Screenshots:** save throwaways to `/tmp`, not the repo. `scripts/screenshot.mjs`
-  is a local-only helper (gitignored).
-- **Ask a maintainer** for product facts vs. content choices instead of guessing.
+- **Screenshots:** keep throwaways out of the repo — wherever the harness puts
+  temp files is fine. `scripts/screenshot.mjs` is a local-only helper
+  (gitignored); `scripts/shoot.mjs` is **not** gitignored, so don't commit it.


### PR DESCRIPTION
`AGENTS.md` told every contributor and AI agent that production deploys through the `aws s3 sync` in `.github/workflows/main.yml`. It does not — `help.keboola.com` is served by Vercel from `main`. Anyone reasoning about caching, 404 handling or trailing slashes from that workflow reached the wrong conclusion.

No docs pages and no build behaviour change here — only the two contributor guides and `.gitignore`. A read-through is enough.

## Changes

- **AGENTS.md** — Vercel is production; `main.yml`'s S3 sync explicitly is not. Adds `scripts/check-redirects.mjs` to the repo map (the dev→help URL contract, PRDCT-565).
- **CLAUDE.md** — new "How to work with me": when to invoke a skill, and standing authorization to run the `fact-checker` / `guide-tester` subagents after docs changes. Drops four notes that only repeated AGENTS.md.
- **.gitignore** — `.claude` without a trailing slash. With the slash it matches directories only, so when `.claude` is a symlink to a rig kept outside the repo, the symlink itself stayed untracked-and-committable. Also ignores local-only planning docs and `scripts/shoot.mjs`.

## Verification

- `npm run build` clean.
- `git check-ignore -v .claude` matches the new rule; `git status` no longer offers the symlink.

Found while auditing the local agent setup; the same audit produced the lint-detector fixes in #1002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
