### PR TITLE
Document text-column widening and DuckDB output data types (CFTL-713 / SUPPORT-16781)

### DIFF
--- a/src/content/docs/storage/tables/data-types/index.md
+++ b/src/content/docs/storage/tables/data-types/index.md
@@ -66,6 +66,8 @@ Source data types are mapped to a destination using a **base type**. The current
 
 For detailed mappings, please refer to the [conversion table](https://developers.keboola.com/extend/common-interface/manifest-files/out-tables-manifests-native-types/#data-type-conversions). You can also view the extracted data types in the [storage table](/storage/tables/) detail.
 
+Because this list is deliberately small, when a component describes its output with base types, a source type that has no equivalent among them (for example `TIME`, `INTERVAL`, `UUID`, `BLOB`, `JSON`, arrays, or structs) arrives in Storage as `STRING`. Components that write the backend's own types instead are not limited in this way. Length, precision, and scale are only carried over when the source type actually holds them --- if the source engine discards them, they cannot be reconstructed later. See [output data types in DuckDB transformations](/transformations/duckdb/#output-data-types) for a concrete example of both cases.
+
 ### How to Define Data Types
 
 #### Using actual data types of the storage backend
@@ -94,7 +96,7 @@ Specifying native types using Keboola’s [base types](/storage/tables/data-type
 ```
 
 ### Changing Types of Existing Typed Columns
-You **cannot change the type of a column in a typed table once it has been created**. However, there are multiple workarounds to address this limitation:
+You **cannot change the type of a column in a typed table once it has been created**. The only exception is [widening a text column](#widening-a-text-column). Otherwise, there are multiple workarounds to address this limitation:
 
 **For tables using full load:** Drop the table and create a new one with the correct types. Then, load the data into the newly created table.
 
@@ -110,6 +112,17 @@ You **cannot change the type of a column in a typed table once it has been creat
 :::caution
 **Important:** Always verify other configurations that depend on the table to avoid schema mismatches. Also, pay special attention to writers (data destination connectors), particularly if the table already exists in the destination system. Mismatched schemas between the source and destination can lead to errors.
 :::
+
+#### Widening a Text Column
+The **length** of a text column (`VARCHAR` on Snowflake, `STRING(n)` on BigQuery) can be increased in place. If a Snowflake transformation redefines an existing column with a longer length --- for example from `VARCHAR(2)` to `VARCHAR(50)` --- Storage widens the column instead of failing the load. It is a metadata-only change, so existing rows are preserved, for both full and incremental loads. The type itself still cannot be changed this way.
+
+:::caution
+**Widening is one-way.** Once a column has been widened to `VARCHAR(50)`, a load that declares the original `VARCHAR(2)` fails --- loading a shorter length into a longer column is not supported.
+
+As a result, `VARCHAR(n)` written in a transformation is not a durable constraint: the length that is enforced is always the **current definition of the column in Storage**, not the one in your latest query. If you rely on a maximum width being enforced, [create the table as typed first](#how-to-create-a-typed-table) and keep that definition as the source of truth.
+:::
+
+The same length change --- together with a column's nullability and default value --- can also be made explicitly through the [update column definition endpoint](https://api.keboola.com/?service=storage#put-/v2/storage/tables/-id-/columns/-column-/definition) of the Storage API, without running a transformation.
 
 ### How to Create a Typed Table Based on a Non-Typed Table
 If you have a non-typed table, `non_typed_table`, with undefined data types and want to convert it into a typed table, follow these steps:

--- a/src/content/docs/transformations/duckdb/index.md
+++ b/src/content/docs/transformations/duckdb/index.md
@@ -125,9 +125,49 @@ so aggregate functions and type-specific operations work as expected.
 
 ![Screenshot - Successful Job With Type Inference](/transformations/duckdb/job-success.png)
 
-The output table then contains properly typed columns:
+The output table then contains typed columns instead of strings:
 
 ![Screenshot - Output Table With Typed Columns](/transformations/duckdb/output-typed-columns.png)
+
+The exact types the columns get are decided by the mapping described in [Output Data Types](#output-data-types) --- they are not copied verbatim from the casts in your SQL.
+
+## Output Data Types
+
+When a transformation finishes, the component reads the schema of each output table from DuckDB and translates it into Keboola [base types](/storage/tables/data-types/#base-types), which Storage then turns into backend types (for example `TIMESTAMP` becomes `TIMESTAMP_NTZ` on Snowflake).
+
+| DuckDB type | Keboola base type | Notes |
+|---|---|---|
+| `TINYINT`, `SMALLINT`, `INTEGER`, `BIGINT`, `HUGEINT` and their unsigned variants | `INTEGER` | |
+| `DECIMAL(p,s)`, `NUMERIC(p,s)` | `NUMERIC` | Precision and scale are carried over |
+| `DOUBLE` | `FLOAT` | |
+| `BOOLEAN` | `BOOLEAN` | |
+| `DATE` | `DATE` | |
+| `TIMESTAMP`, `TIMESTAMP WITH TIME ZONE` | `TIMESTAMP` | Storage default precision (`TIMESTAMP_NTZ(9)` on Snowflake) |
+| `TIMESTAMP_S`, `TIMESTAMP_MS`, `TIMESTAMP_NS` | `TIMESTAMP` | Precision `0`, `3`, and `9` respectively |
+| `VARCHAR`, `CHAR`, `BPCHAR`, `TEXT`, `STRING` | `STRING` | Length is not carried over, see below |
+| Everything else --- `FLOAT`/`REAL`, `TIME`, `INTERVAL`, `UUID`, `BLOB`, `JSON`, arrays, `STRUCT`, `MAP`, `ENUM` | `STRING` | |
+
+Three consequences are worth knowing before you design your output tables.
+
+**DuckDB types with no Keboola equivalent become strings.** Base types are limited to `STRING`, `INTEGER`, `NUMERIC`, `FLOAT`, `BOOLEAN`, `DATE`, and `TIMESTAMP`, so a `TIME`, `INTERVAL`, or `JSON` column lands in Storage as text. If you need such a value in a typed form downstream, split it into supported types in the transformation (for example a `TIME` into an hour and a minute integer, or a `JSON` document into columns).
+
+**Single-precision floats are not mapped.** DuckDB reports both `FLOAT` and its alias `REAL` as `FLOAT`, which is not among the mapped types, so such a column also arrives as text. Cast single-precision values to `DOUBLE` (or `DECIMAL(p,s)`) if you need a numeric column in Storage.
+
+**`VARCHAR(n)` length cannot be preserved.** DuckDB [does not store the length of a `VARCHAR`](https://duckdb.org/docs/stable/sql/data_types/text) --- it accepts `VARCHAR(n)` only for compatibility and discards `n` immediately. By the time the output schema is read, the length is gone, so a column cast as `VARCHAR(2)` reaches Storage as a full-width string (`VARCHAR(16777216)` on Snowflake).
+
+:::tip
+To have a maximum width (or a specific timestamp precision) actually enforced, [create the output table as a typed table](/storage/tables/data-types/#how-to-create-a-typed-table) with the definition you want before running the transformation. The transformation loads *into* the existing definition rather than overriding it, so an over-long value fails the job with an error such as this one on Snowflake:
+
+```
+An exception occurred while executing a query: User character length limit (2) exceeded by string 'ABCDEF'
+```
+:::
+
+Note that this cuts both ways: the definition that applies is always the one the table already has in Storage. Because the component never declares a length for string columns, an existing column keeps its original definition, and a change in the mapping (or in your casts) only shows up on a **newly created** output table. See [changing types of existing typed columns](/storage/tables/data-types/#changing-types-of-existing-typed-columns) for the ways around that.
+
+:::caution
+Arrays of a parameterized type are a known gap: DuckDB reports such a column as `DECIMAL(10,2)[]`, and the component reads only the leading type name, so the column is declared as `NUMERIC(10,2)` while the exported value is still an array literal --- and the load then fails on the type mismatch. Cast arrays (and other nested values) to text explicitly, for example `CAST("my_array" AS VARCHAR)`.
+:::
 
 ## Example
 
@@ -259,6 +299,8 @@ FROM "source";
 ```
 
 When **Infer input table data types** is enabled, DuckDB automatically infers the correct types and you can use them directly.
+
+For the other direction --- which types your output tables end up with in Storage --- see [Output Data Types](#output-data-types).
 
 ### Memory Management for Large Datasets
 


### PR DESCRIPTION
Docs follow-up to **CFTL-713 / SUPPORT-16781** (Košík.cz). Engineering on the ticket is done; these are the two documentation gaps the customer and @matyas-jirat asked for.

### Changes

**`/storage/tables/data-types/` (Native Data Types)** — the page stated flatly that a typed column's type cannot be changed after creation, with no exception. It now documents that the **length of a text column can be increased in place** (`VARCHAR(2)` → `VARCHAR(50)`, metadata-only, rows preserved, full and incremental), that **widening is one-way** so a later shorter declaration fails, and therefore that `VARCHAR(n)` written in a transformation is not a durable constraint — the enforced length is the current Storage definition. Also links the `PUT …/columns/{column}/definition` endpoint that makes the same change explicitly, and scopes the new Base Types note to components that describe their output with base types.

**`/transformations/duckdb/`** — new **Output Data Types** section: the DuckDB → Keboola base type mapping table, what arrives as text and why, that `VARCHAR(n)` length cannot survive DuckDB, and the pre-created typed output table as the supported way to enforce a width or pin timestamp precision. The line "The output table then contains properly typed columns" — which the customer read as "my casts are reproduced" — is reworded.

### Verification

The mapping table was checked against `keboola/component-duckdb-transformation` `src/component.py` (`_map_base_type`, `duckdb_type_to_base_type`, `_LENGTH_BEARING_TYPES`), not against the ticket thread, and DuckDB's own `DESCRIBE` output (duckdb 1.5.5). Two things that turned up while verifying and are now documented as behaviour:

- **`FLOAT`/`REAL` is not mapped.** DuckDB reports both as `FLOAT`; the component has no `FLOAT` branch, so such a column falls through to `STRING`. The page tells readers to cast to `DOUBLE`. Worth a component fix separately (`REAL` is in the mapping code but unreachable, since `REAL` is only a DuckDB alias).
- **Arrays of a parameterized type** (`DECIMAL(10,2)[]`) are declared as `NUMERIC(10,2)` because only the leading type name is read. Documented in a caution with the cast-to-text workaround.

The timestamp-precision row (`TIMESTAMP_S/_MS/_NS` → `0`/`3`/`9`) matches released behaviour as of component **0.1.7** (component PR #21, merged and released 2026-08-05) — verified in `main`.

`npm run build` is clean and `scripts/audit-phase2.mjs` shows no new issues (147 total, same as `main`; all 45 broken links pre-existing).

### One note for the reviewer

❓ **Text-column widening would benefit from a Storage owner's nod.** The behaviour is reproduced by the customer on a production Snowflake project (screenshots in the ticket) and the widen/one-way logic is visible in `php-table-backend-utils` (`SnowflakeTableQueryBuilder::getUpdateColumnFromDefinitionQuery`, `CANNOT_DECREASE_LENGTH`), but that the **load path** applies it — and that it holds for incremental loads and on BigQuery — is only confirmed empirically, not in public code. Component Factory considers `VARCHAR` out of their scope, so if anyone from Storage can confirm or correct that paragraph, I'll adjust the wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)