### PR TITLE
PRDCT-612: port options.encryption_hint from developers-docs before the dev pages retire

### DIFF
--- a/src/content/docs/extend/component/ui-options/configuration-schema/examples/index.md
+++ b/src/content/docs/extend/component/ui-options/configuration-schema/examples/index.md
@@ -146,6 +146,30 @@ Allowed options: mode, placeholder, autofocus, lineNumbers lint
 Available modes: `text/x-sfsql`, `text/x-sql`, `text/x-plsql`, `text/x-python`, `text/x-julia`, `text/x-rsrc`, `application/json`
 JSON mode supports encryption. Default mode is `application/json` . You should set type base on mode (string or object).
 
+A JSON-mode editor stores the parsed JSON, so keys prefixed with `#` inside the field are
+[encrypted](/overview/encryption/) on save. The UI states this in a note below the editor. If the field does not hold
+Keboola configuration (a vendor query filter, a request payload template), that note advertises something the component
+cannot use — the platform would encrypt the key and the component would receive the ciphertext. Hide the note with
+`options.encryption_hint: false`:
+
+```json
+{
+  "filters": {
+    "type": "object",
+    "title": "Filters",
+    "format": "editor",
+    "options": {
+      "editor": {
+        "mode": "application/json"
+      },
+      "encryption_hint": false
+    }
+  }
+}
+```
+
+The option only affects the note. Encryption itself is unchanged: a `#`-prefixed key is still encrypted on save.
+
 **JsonSchema examples:**
 
 ```json

--- a/src/content/docs/extend/component/ui-options/configuration-schema/index.md
+++ b/src/content/docs/extend/component/ui-options/configuration-schema/index.md
@@ -66,6 +66,7 @@ The following `options` keys can be used in property definitions:
 | `options.grid_columns` | Number of grid columns (1–12) in `grid`/`grid-strict` layouts |
 | `options.grid_break` | Force a new row in grid layouts |
 | `options.editor` | CodeMirror editor options: `mode`, `lineNumbers`, `lint`, `input_height` |
+| `options.encryption_hint` | Set to `false` to hide the "properties prefixed with `#` will be encrypted" note under a JSON-mode `editor` field. See [Codemirror Editor](/extend/component/ui-options/configuration-schema/examples/#codemirror-jsonsqlpython-editor). |
 | `options.input_height` | Height for textarea fields (e.g., `"100px"`) |
 | `options.inputAttributes` | HTML input attributes (e.g., `placeholder`) |
 | `options.only_keys` | SSH editor variant showing only key fields |


### PR DESCRIPTION
`options.encryption_hint` was documented on **developers-docs on 2026-08-04** (`dd30fdf8`, Jakub Kotek — the docs half of keboola/ui#7627), five days *after* the same two pages merged into help. The edit therefore exists only on the dev copy, and [developers-docs#406](https://github.com/keboola/developers-docs/pull/406) — the delete-from-dev PR, already approved — would retire it.

This is the case Jordan named on the 08-05 sync: *"there's something on a components page which we already moved, but now it exists only on developer docs — make sure that also gets handled."* It is also why #406 conflicts: the only two files it cannot merge cleanly are these two.

## What it adds

- `configuration-schema/index.md` — one row in the `options` table.
- `configuration-schema/examples/index.md` — the paragraph and JSON example under **Codemirror (json/sql/python..) Editor**: a JSON-mode editor stores parsed JSON, so `#`-prefixed keys inside it are encrypted on save and the UI says so; when the field does not hold Keboola configuration that note advertises something the component cannot use, so `options.encryption_hint: false` hides it. Encryption behaviour itself is unchanged.

Ported verbatim, with two adjustments for the help side: the `---` in the prose becomes a real em dash (per the corpus-wide sweep in #1069/#1070), and the encryption cross-link uses the local `/overview/encryption/` convention that three neighbouring `/extend/` pages already use.

## Verification

- `npm run build` clean, 308 pages.
- `node scripts/audit-phase2.mjs`: 0 missing images. Broken internal links go **35 → 36**, and the one added is `/extend/component/ui-options/configuration-schema/examples/ → /overview/encryption/` — a known forward-ref, since `/overview/` has not been migrated yet. It resolves when that unit lands; the alternative was an absolute link to a site we are retiring.
- The anchor `#codemirror-jsonsqlpython-editor` resolves on the target page today.

## Merge order

This first, then rebase and merge **developers-docs#406**. Merging #406 first would drop the content from the live docs entirely.