### PR TITLE
docs: fix stale UI labels in Kai and HTTP connector pages

### DIFF
--- a/src/content/docs/components/extractors/storage/http/index.md
+++ b/src/content/docs/components/extractors/storage/http/index.md
@@ -19,18 +19,18 @@ Enter a base URL -- the prefix for all downloaded CSV files from a given website
 
 The base URL can also contain folder specification if the same folder is used for all files downloaded using this base URL.
 
-## Add Tables
-To create a new table, click the **Add Table** button and assign a name.
-It will be used to create the destination table name in Storage and can be modified.
+## Add Rows
+In the **Rows** section, click **Add Row** and assign a name.
+It seeds the destination table name in Storage and can be modified.
 
 ![Screenshot - Create table](/components/extractors/storage/http/http-2.png)
 
-Each table has different settings (path, load type, etc.) but they all share the same base URL.
-The configuration can extract as many tables as you wish *(to add more test tables, use our other sample tables: /tutorial/account.csv, /tutorial/level.csv, and /tutorial/user.csv)*. Configured tables are stored as [configuration rows](/components/#configuration-rows).
+Each row has different settings (path, load type, etc.) but they all share the same base URL.
+The configuration can extract as many tables as you wish *(to add more test tables, use our other sample tables: /tutorial/account.csv, /tutorial/level.csv, and /tutorial/user.csv)*. Rows here are standard [configuration rows](/components/#configuration-rows).
 
 ### Specify File to Download
 
-For each table you have to specify a path that leads to a single CSV file or to an archive (GZ and ZIP are supported),
+For each row you have to specify a path that leads to a single CSV file or to an archive (GZ and ZIP are supported),
 which will be imported into a single table in Storage.
 
 ![Screenshot - Download Settings](/components/extractors/storage/http/http-3.png)
@@ -42,15 +42,18 @@ want to load one of our tutorial tables, enter its path, e.g., `/tutorial/opport
 
 ![Screenshot - Save Settings](/components/extractors/storage/http/http-4.png)
 
-- The initial value in **Table Name** is derived from the configuration table name. You can change it at any time; however,
+- The initial value in **Table name** is seeded from the row name. You can change it at any time; however,
 the [Storage bucket](/storage/buckets/) where the table will be saved to cannot be changed.
-- **Incremental Load** will turn on [incremental loading to Storage](/storage/tables/#incremental-loading). The result of the
+- **Incremental load** will turn on [incremental loading to Storage](/storage/tables/#incremental-loading). The result of the
 incremental load depends on other settings (mainly **Primary Key**).
 - **Delimiter** and **Enclosure** specify the CSV settings.
 
 ### Header & Primary Key
 
 ![Screenshot - Header & Primary Key](/components/extractors/storage/http/http-5.png)
+
+**Read Header** determines the column names. It already defaults to **Read from the file(s) header**, which is what
+most CSV files need — leave it alone unless your file has no header row.
 
 There are three options for determining column names:
 
@@ -59,7 +62,7 @@ There are three options for determining column names:
  A random file will be chosen to extract the header and the first line in all files will be removed.
  - **Generate automatically** — The columns will be named sequentially as `col_1`, `col_2` and so on.
 
-**Primary Key** can be used to specify the primary key in Storage, which can be used with **Incremental Load**. 
+**Primary Key** can be used to specify the primary key in Storage, which can be used with **Incremental load**. 
 
 The data source connector also supports [Debug mode](/components/#debug-mode), all supported
 parameters are described in the [GitHub repository](https://github.com/keboola/http-extractor).

--- a/src/content/docs/kai/getting-started.md
+++ b/src/content/docs/kai/getting-started.md
@@ -11,15 +11,15 @@ Kai is now in **Public Beta** and available to all users in supported stacks.
 
 ### Enabling Kai
 
-Every user can see the Kai button in their project (on supported stacks). To enable Kai:
+Every user can see **Kai Agent** in their project (on supported stacks). To enable Kai:
 
-- **Organization Admins** — Can enable the feature directly from the chat screen when first clicking the Kai button
+- **Organization Admins** — Can enable the feature directly from the chat screen when first opening Kai Agent
 - **Other users** — Need to ask their Organization Admin to enable the feature, or [contact Keboola Support](mailto:support@keboola.com) for assistance
 - **Settings** — Kai can also be enabled via **Settings → Features** in your project
 
 ## Opening Kai
 
-Click the **KAI** button in your project's top navigation bar, or use keyboard shortcuts:
+Click **Kai Agent**, marked with a *Beta* pill, in your project's top bar, or use keyboard shortcuts:
 
 | Shortcut | Action |
 |----------|--------|

--- a/src/content/docs/kai/index.md
+++ b/src/content/docs/kai/index.md
@@ -39,7 +39,7 @@ Kai is Keboola's embedded AI assistant—a context-aware data engineering co-pil
 
 ## Getting Started
 
-Kai is now in **Public Beta** and available to all users. Look for the **KAI** button in your project's navigation bar.
+Kai is now in **Public Beta** and available to all users. Look for **Kai Agent**, marked with a *Beta* pill, in your project's top bar.
 
 - **Organization Admins** can enable Kai directly from the chat screen
 - **Other users** can request access from their Organization Admin or [contact Keboola Support](mailto:support@keboola.com)


### PR DESCRIPTION
Both verified against a live project on 2026-08-04.

kai/: the assistant is "Kai Agent" with a Beta pill in the top bar, not a
"KAI" button in the navigation bar. Fixed on index.md and getting-started.md.

components/extractors/storage/http/: the connector uses a Rows section with
an "Add Row" button, not "Add Table"; the table name is seeded from the row
name rather than derived from a configuration table name; and the settings
are "Table name" and "Incremental load". Also note that Read Header already
defaults to reading the file's header, so most readers never touch it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MD35Q1SAwqReqedaq4m2VL