### PR TITLE
Remove the Usage File section

### DIFF
--- a/src/content/docs/extend/common-interface/config-file/index.md
+++ b/src/content/docs/extend/common-interface/config-file/index.md
@@ -184,34 +184,6 @@ are run simultaneously in the **same project**, the one writing data later wins.
 as an HTTP cookie than as a database. A typical use for the state file would be saving the last record
 loaded from some API to enable incremental loads.
 
-## Usage File
-
-Unlike the state file, the **usage file is one way only** and has a pre-defined structure.
-The usage file is used to pass information from the component to Keboola.
-Metrics stored are used to determine how much resources the job consumed and translate the usage to Keboola
-credits; this is very useful when you need your customers to pay using your component or service.
-
-The usage file is located at `/data/out/usage.json`. It should contain an array of objects
-keeping information about the consumed resources. The objects have to contain only two keys, `metric`
-and `value`, as in the example bellow:
-
-```json
-[
-    {
-        "metric": "API calls",
-        "value": 150
-    }
-]
-```
-
-This structure is processed and stored within a job, so it can be analyzed, processed and aggregated later.
-
-To keep track of the consumed resources in the case of a component failure, **it is recommended to
-write the usage file regularly** during the component run, not only at the end.
-
-*Note: As the structure of the state file is pre-defined, the content of the usage file is strictly
-validated and a wrong format will cause a component failure.*
-
 ## Examples
 To create an example configuration, use the [Run Job API call in debug mode](/extend/component/running/#preparing-data-folder). You will get a
 `stage_0.zip` archive in your **Storage** > **File Uploads**, which will contain the `config.json` file.


### PR DESCRIPTION
## Context

Linear: [PAT-2006](https://linear.app/keboola/issue/PAT-2006)

The usage file has never worked. A component could report its own consumption by writing `out/usage.json`; `job-runner`'s `UsageFile` read it, validated it, and handed it to `Client::addJobUsage()` — a method with an empty body (`// todo implement this`) since it was introduced on **2019-07-04** (`af3033b`). Verified at the version pinned into job-runner's production build (`keboola/job-queue-internal-api-php-client` 25.5.0). `job-runner` was the only caller, and nothing subclasses `Client`.

So `usageData` is `[]` on every queue v2 job (100% of jobs in the last 90 days — 23,010,147). Nothing consumes it either: zero hits for `usageData`/`usage_data` in `telemetry-billing`, `billing-api`, `telemetry-billing-gcp` or `connection`, and the telemetry `kbc_job` extract has no usage column.

`UsageFileTest` mocked `addJobUsage` and asserted it was called, so it stayed green against a method that does nothing — that is why this survived seven years.

Only one component in the org writes a usage file: `keboola.ex-google-analytics-v4`. Its reports have been discarded all along, so nothing changes for it.

## Deployment order for this batch

1. **`keboola/docker-bundle`** — `Runner::run()` loses its fifth parameter
2. **`keboola/job-runner`** — then `composer update keboola/dockerbundle`
3. **`keboola/job-queue`** — removes `addJobUsage()` from the client. The standalone `keboola/job-queue-internal-api-php-client` is synced from the monorepo, so it picks this up automatically and then needs a new major tag.
4. **`keboola/developers-docs`** + **`keboola/connection-docs`** — last, so the docs do not get ahead of the deployed behaviour

## What this PR does

Removes the **Usage File** section from the common-interface config-file page.

Of its three claims, two were false and the third is being made false by the code change:

| Claim | Status |
| -- | -- |
| "the content of the usage file is strictly validated and a wrong format will cause a component failure" | true today — but the validating code is removed in keboola/docker-bundle#810 |
| "processed and stored within a job, so it can be analyzed, processed and aggregated later" | false since 2019 |
| "translate the usage to Keboola credits … when you need your customers to pay using your component or service" | false since 2019 |

So the net effect of following this page was: a vendor could fail their own customers' jobs with a malformed `usage.json` and get nothing in return.

Checked that no page links to the removed `#usage-file` anchor.

## Release Notes

**Justification, description**
The page documented a monetization mechanism that has never been wired up. Keeping it invites component authors to build against a dead feature.

**Plans for Customer Communication**
Worth a line in the developer-facing changelog: the usage file is withdrawn because it never took effect. Any vendor who built on it has been getting `[]` from the Jobs API all along, so no invoicing behaviour changes. Nothing to notify end customers about.

**Impact Analysis**
Documentation only. The same section is removed from the sibling docs repo in the paired PR, since both sites publish it.

**Deployment Plan**
Merge last in the batch, after the job-runner release, so the docs do not describe behaviour that is still live.

**Rollback Plan**
Revert the commit.

**Post-Release Support Plan**
If a vendor asks where the usage file went, the answer is that it never stored anything; point them at PAT-2006.

