### PR TITLE
PRDCT-651: make .mdx safe to use — redirects, raw markdown, and GFM tables

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -61,6 +61,9 @@ export default defineConfig({
       },
     }),
     // Must come AFTER starlight() so MDX code blocks use astro-expressive-code.
-    mdx(),
+    // GFM has to be asked for explicitly here. Without it, MDX pages render
+    // pipe tables as literal text — visible corruption, and the reason no page
+    // could safely be converted from .md before now.
+    mdx({ gfm: true }),
   ],
 });

--- a/src/integrations/page-markdown.mjs
+++ b/src/integrations/page-markdown.mjs
@@ -16,18 +16,76 @@ import { fileURLToPath } from 'node:url';
  */
 
 /**
- * Recursively find all .md files in a directory.
+ * Recursively find all .md and .mdx files in a directory.
  */
 function findMarkdownFiles(dir, files = []) {
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry);
     if (statSync(full).isDirectory()) {
       findMarkdownFiles(full, files);
-    } else if (extname(full) === '.md') {
+    } else if (extname(full) === '.md' || extname(full) === '.mdx') {
       files.push(full);
     }
   }
   return files;
+}
+
+/**
+ * Reduce an .mdx body to plain markdown.
+ *
+ * The raw-markdown copies exist so an agent can read a page as text, so MDX
+ * machinery has to come out rather than ship verbatim: a stray
+ * `import ... from '@astrojs/starlight/components';` or a bare `<Tabs>` tag is
+ * noise at best and misleading at worst.
+ *
+ * Component wrappers are dropped and their children kept, which flattens a
+ * tabbed page into its sections one after another — the right shape for a
+ * reader who cannot click a tab. Children are also dedented by one level per
+ * wrapper, because MDX authors indent them and four leading spaces would
+ * otherwise turn ordinary prose into an indented code block.
+ *
+ * Components are matched on an uppercase initial, the JSX convention, so
+ * lowercase HTML written inline in a page is left alone.
+ */
+function stripMdx(body) {
+  const withoutImports = body.replace(/^import\s[^\n]*?;\s*$/gm, '');
+  const withComments = withoutImports.replace(
+    /\{\/\*([\s\S]*?)\*\/\}/g,
+    (_, inner) => `<!--${inner}-->`,
+  );
+
+  const INDENT = '    ';
+  const open = /^\s*<[A-Z][A-Za-z0-9]*\b[^>]*(?<!\/)>\s*$/;
+  const selfClosing = /^\s*<[A-Z][A-Za-z0-9]*\b[^>]*\/>\s*$/;
+  const close = /^\s*<\/[A-Z][A-Za-z0-9]*\s*>\s*$/;
+
+  let depth = 0;
+  const out = [];
+
+  for (const line of withComments.split('\n')) {
+    if (selfClosing.test(line)) continue;
+    if (close.test(line)) {
+      depth = Math.max(0, depth - 1);
+      continue;
+    }
+    if (open.test(line)) {
+      // A tab or card carries its identity in `label`; without it the
+      // flattened sections run together and a reader cannot tell which
+      // variant is which.
+      const label = line.match(/\blabel=["']([^"']+)["']/);
+      if (label) out.push('', `**${label[1]}**`, '');
+      depth += 1;
+      continue;
+    }
+
+    let text = line;
+    for (let i = 0; i < depth && text.startsWith(INDENT); i += 1) {
+      text = text.slice(INDENT.length);
+    }
+    out.push(text);
+  }
+
+  return out.join('\n').replace(/\n{3,}/g, '\n\n');
 }
 
 /**
@@ -93,7 +151,9 @@ export default function pageMarkdown() {
             continue;
           }
 
-          const body = stripFrontmatter(content).trim();
+          const isMdx = extname(file) === '.mdx';
+          const raw = stripFrontmatter(content);
+          const body = (isMdx ? stripMdx(raw) : raw).trim();
           const md = (fm.title ? `# ${fm.title}\n\n` : '') + body + '\n';
 
           mkdirSync(mdDir, { recursive: true });

--- a/src/integrations/redirect-from.mjs
+++ b/src/integrations/redirect-from.mjs
@@ -15,14 +15,14 @@ import { fileURLToPath } from 'node:url';
  */
 
 /**
- * Recursively find all .md files in a directory.
+ * Recursively find all .md and .mdx files in a directory.
  */
 function findMarkdownFiles(dir, files = []) {
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry);
     if (statSync(full).isDirectory()) {
       findMarkdownFiles(full, files);
-    } else if (extname(full) === '.md') {
+    } else if (extname(full) === '.md' || extname(full) === '.mdx') {
       files.push(full);
     }
   }


### PR DESCRIPTION
Writing a page as `.mdx` instead of `.md` silently costs it three things in this repo. Nothing fails, the build is green and the page looks broadly right, which is why none of it had been noticed.

1. **Its redirect stubs.** `redirect_from` is ignored, so old URLs 404.
2. **Its raw-markdown copy** — the `help.keboola.com/<slug>/index.md` an agent reads.
3. **Its tables.** MDX does not render GFM here: a pipe table comes out as literal pipes. This one is visible corruption on the page.

`cli/getting-started.mdx` is the only `.mdx` page today. It has had no raw-markdown twin all along, and escaped the other two only by having no `redirect_from` and no tables.

Found while converting a Getting Started page to `.mdx` for Starlight `<Tabs>` on the Snowflake-vs-BigQuery query blocks. Redirects dropped 220 → 219, taking `/tutorial/manipulate/` with them; raw-markdown pages 308 → 307; and the sample-data table rendered as pipes. That conversion was reverted. This unblocks it.

## What changed

**`redirect-from.mjs`** — wider filter. It only reads frontmatter, identical in either format.

**`page-markdown.mjs`** — the filter, plus a new `stripMdx`, because this one writes the source body out as text and an `.mdx` body carries machinery a reader should not see. It drops top-level imports, turns `{/* … */}` back into HTML comments so the same notes survive as on a `.md` page, and removes component wrappers while keeping their children.

Two details decide whether that output is usable:

- **Children are dedented one level per wrapper.** MDX authors indent them, and four leading spaces would otherwise render ordinary prose as an indented code block — which is what the first attempt did to the CLI install instructions.
- **A wrapper's `label` is emitted as a bold line.** A flattened `<Tabs>` then reads **macOS** … **Linux** … instead of the same paragraph three times with nothing to tell the variants apart.

Components are matched on an uppercase initial — the JSX convention — so lowercase HTML written inline in a page is untouched.

**`astro.config.mjs`** — `mdx({ gfm: true })`. `remark-gfm` would also work but it is only a transitive dependency here, so importing it directly would break on any lockfile change.

## Verification

Against this branch's base:

| | before | after |
|---|---|---|
| raw-markdown pages | 306 | **307** |
| tables site-wide | 61 | 61 |
| beacon grids | 5 | 5 |
| broken internal links | 35 | 35 |
| audit total | 140 | 140 |

The new file is `cli/getting-started/index.md`; it carries no imports, no JSX and no MDX comments, and its install steps come out as prose plus fenced code rather than one indented block.

The two fixes that cannot show up in these numbers were proven separately, since nothing in `.mdx` currently declares `redirect_from` or contains a table:

- adding a temporary `redirect_from` to the CLI page took redirects 199 → 200 and produced a working stub to `/cli/getting-started/`, then was reverted — the probe is not in this diff;
- on a prototype branch where the Getting Started load page is `.mdx` with two tables, table count goes 0 → 2 with the config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)