### PR TITLE
PRDCT-663: drop the Public Beta wording from the Kai section

### DIFF
--- a/src/content/docs/kai/getting-started.md
+++ b/src/content/docs/kai/getting-started.md
@@ -7,7 +7,7 @@ slug: 'kai/getting-started'
 
 ## Access
 
-Kai is now in **Public Beta** and available to all users in supported stacks.
+Kai is available on all supported stacks; the feature has to be enabled in your project first.
 
 ### Enabling Kai
 
@@ -19,13 +19,14 @@ Every user can see the Kai button in their project (on supported stacks). To ena
 
 ## Opening Kai
 
-Click the **KAI** button in your project's top navigation bar, or use keyboard shortcuts:
+Click the **Kai Agent** button in your project's top bar, or use keyboard shortcuts:
 
 | Shortcut | Action |
 |----------|--------|
 | **A** | Open the chat window (shows recent conversation) |
 | **Ctrl + Shift + A** | Open a new chat |
 
+<!-- TODO(human-review, Jordan): kai-welcome.png still shows the Beta badge/pill on the Kai button. It cannot be reshot clean before the pill retires on 2026-09-15 — reshoot after that date. -->
 ![Kai Chat Panel](/kai/kai-welcome.png)
 
 ## Example Prompts
@@ -84,7 +85,7 @@ This makes interactions more natural—you can say "analyze this job" while view
 
 ## Rate Limits
 
-**Kai is free during the public beta period.**
+<!-- VERIFY(Jordan): the pricing line that stood here was removed with the beta scrub (pill retires 2026-09-15, call 2026-08-21). Confirm whether a pricing/entitlement statement replaces it or the per-plan message limits below stand alone — pricing is not documented here per the guardrail. -->
 
 Each user receives **150 turns (messages) per month per project** on contracted plans. The limit resets at the beginning of each calendar month.
 

--- a/src/content/docs/kai/index.md
+++ b/src/content/docs/kai/index.md
@@ -39,7 +39,7 @@ Kai is Keboola's embedded AI assistant—a context-aware data engineering co-pil
 
 ## Getting Started
 
-Kai is now in **Public Beta** and available to all users. Look for the **KAI** button in your project's navigation bar.
+Every user on a supported stack can see the **Kai Agent** button in the project's top bar, but the feature has to be switched on first:
 
 - **Organization Admins** can enable Kai directly from the chat screen
 - **Other users** can request access from their Organization Admin or [contact Keboola Support](mailto:support@keboola.com)


### PR DESCRIPTION
## Why

The Beta pill on the Kai button retires on **2026-09-15** (Jordan, 2026-08-21 call), so the docs must stop calling Kai a beta before that date. The getting-started arc was already scrubbed in #1071 (`d0b340ef`); this PR finishes the job in `/kai/` itself — the hand-off comment in #1071 explicitly scheduled it.

Linear: PRDCT-663.

## What

Exhaustive for the section: a case-insensitive grep of `src/content/docs/kai/` finds no other beta mentions, and no `/ai/` page carries Kai-beta wording.

- `kai/index.md` — "Kai is now in **Public Beta** and available to all users…" → "Every user on a supported stack can see the **Kai Agent** button in the project's top bar, but the feature has to be switched on first:" (drops the beta clause, fixes the stale `KAI` label to the live **Kai Agent**, and stops contradicting the enablement bullets right below it).
- `kai/getting-started.md` (Access) — beta clause dropped; reworded so availability (stacks) and entitlement (project-level enable) don't conflict.
- `kai/getting-started.md` (Opening Kai) — stale `KAI` label → **Kai Agent**, matching the index and #1079.
- `kai/getting-started.md` (Rate Limits) — "**Kai is free during the public beta period.**" removed. **No post-beta pricing is invented** (docs guardrail: pricing is not documented); a `VERIFY(Jordan)` comment flags what, if anything, replaces the free-of-charge claim. The per-plan message limits and all enablement facts are untouched.
- `kai/getting-started.md` — `TODO(human-review, Jordan)` flag on `kai-welcome.png`: the screenshot still shows the Beta badge and can only be reshot clean after 2026-09-15.

Scrub pattern matches #1071: drop the Beta clause, keep enablement/gating facts, introduce no new status word.

## Conservation

Removed claim: the free-during-beta pricing line in Rate Limits — logged here and flagged in-page as `VERIFY(Jordan)`. Everything else is rewording in place.

## Coordination with #1079

#1079 (`docs/stale-ui-labels`) rewrote two of the same lines and added "marked *Beta*" (accurate when written; stale after 09-15). Its kai/ hunks were updated to the exact same final text as this PR (`kai/index.md` is byte-identical on both branches), so the two PRs merge cleanly in either order.

## Merge timing

The pill is still live until 2026-09-15, so between merge and that date the docs describe the button without beta context while the UI still shows the pill. Merging any time before 09-15 satisfies the instruction; holding until the pill actually drops is equally fine — reviewer's call.

Fact-checker and guide-tester subagents ran on both pages: no blockers; their in-scope findings (label consistency, availability/entitlement wording, screenshot flag, VERIFY comment not quoting the pricing claim verbatim into the published `.md` twin) are incorporated. Build clean (308 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
