### PR TITLE
PRDCT-664: fix Kai chat shortcuts and the supported-stacks claim

### DIFF
--- a/src/content/docs/kai/getting-started.md
+++ b/src/content/docs/kai/getting-started.md
@@ -1,17 +1,19 @@
 ---
 title: Getting Started with Kai
 slug: 'kai/getting-started'
+description: Enable Kai in your project, open the chat with keyboard shortcuts, and send your first prompts.
 ---
 
 
 
 ## Access
 
-Kai is now in **Public Beta** and available to all users in supported stacks.
+<!-- VERIFY(Jordan): single-tenant stack availability. The kai-assistant service is live on all five multi-tenant stacks (checked 2026-08-25 via each stack's public service index); whether single-tenant stacks get Kai is not publicly checkable. If they do, widen the sentence below. -->
+Kai is now in **Public Beta** and available to all users on all [multi-tenant stacks](/overview/#stacks).
 
 ### Enabling Kai
 
-Every user can see the Kai button in their project (on supported stacks). To enable Kai:
+Every user can see the Kai button in their project. To enable Kai:
 
 - **Organization Admins** — Can enable the feature directly from the chat screen when first clicking the Kai button
 - **Other users** — Need to ask their Organization Admin to enable the feature, or [contact Keboola Support](mailto:support@keboola.com) for assistance
@@ -23,8 +25,10 @@ Click the **KAI** button in your project's top navigation bar, or use keyboard s
 
 | Shortcut | Action |
 |----------|--------|
-| **A** | Open the chat window (shows recent conversation) |
-| **Ctrl + Shift + A** | Open a new chat |
+| **A** | Open or close the chat window (opens with your recent conversation) |
+| **Shift + A** | Start a new chat (opens the window if it's closed) |
+| **]** | Switch the open chat between the side panel and full-screen layout |
+| **Ctrl + Enter** (Mac: **⌘ + Enter**) | Approve a pending tool call (see [Action Approval](#action-approval) below) |
 
 ![Kai Chat Panel](/kai/kai-welcome.png)
 
@@ -50,7 +54,7 @@ Click the **KAI** button in your project's top navigation bar, or use keyboard s
 
 When Kai wants to modify your project, you'll see a tool approval prompt. Review what Kai wants to do before approving. All actions are logged in your project's audit trail.
 
-You can also click **Always allow** directly in the approval dialog to skip future confirmations for that specific tool.
+You can also click **Always allow** directly in the approval dialog to skip future confirmations for that specific tool. To approve the pending tool call from the keyboard, press **Ctrl + Enter** (Mac: **⌘ + Enter**).
 
 For more granular control, see [Tool Permissions](/kai/settings/#tool-permissions) in Kai Settings.
 


### PR DESCRIPTION
Fixes two accuracy problems on `kai/getting-started` found during the PRDCT-663 beta scrub. Both corrections come from the product, not from guesswork.

## What changed

- **New-chat shortcut: `Ctrl + Shift + A` → `Shift + A`.** The old combo does not exist in the shipped UI (zero occurrences in the production bundle); the product binds plain `Shift + A` ("New Kai conversation"). The bare `A` row was actually correct — it's a guarded toggle that doesn't fire while typing — so it stays, reworded to say it also closes the panel.
- **Two more Kai shortcuts documented**, straight from the same hotkey registry: `]` switches the open chat between side panel and full-screen, and `Ctrl + Enter` (Mac `⌘ + Enter`) approves a pending tool call (also mentioned in the Action Approval section, where the reader actually needs it).
- **"Supported stacks" → "all [multi-tenant stacks](/overview/#stacks)".** The old qualifier was defined nowhere. Every one of the five multi-tenant stacks' public service index lists `kai-assistant`, so the page now says that and links the stack list. Whether single-tenant stacks get Kai is not publicly checkable → flagged inline as `VERIFY(Jordan)`.
- Added the missing mandatory `description` frontmatter while touching the file.

## Evidence (all checked 2026-08-25)

- Shipped UI bundle `https://ui.keboola-assets.com/kbc-ui/bundle.B9ZzDaj8.js` — hotkey registrations: `a` = Toggle Kai, `shift+a` = New Kai conversation, `]` = Toggle Kai layout (sidebar ↔ fullscreen), `mod+enter` = Approve tool call.
- Live check in a project on connection.europe-west3.gcp: `A` opens the panel with the recent conversation, `Shift + A` opens NEW CHAT, `]` toggles the layout.
- `https://<stack>/v2/storage?exclude=components` on all five multi-tenant stacks lists `kai-assistant`.
- Independent fact-check pass: 7/7 claims confirmed; build + link audit clean.

## Merge order

Overlaps #1097 (PRDCT-663 beta scrub) on the same page — **merge #1097 first**; the rebase of this PR is trivial and I'll handle it.

Linear: [PRDCT-664](https://linear.app/keboola/issue/PRDCT-664/kai-getting-started-wrong-new-chat-shortcut-undefined-supported-stacks) (related: PRDCT-475 — this resolves its shortcuts checklist item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)